### PR TITLE
创建/删光workspace白屏问题修复

### DIFF
--- a/src/components/PtyTerminal.tsx
+++ b/src/components/PtyTerminal.tsx
@@ -131,6 +131,8 @@ export function PtyTerminal({
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const startedRef = useRef(false);
+  const startingRef = useRef(false);
+  const launchTokenRef = useRef(0);
   const [exited, setExited] = useState(false);
 
   // 读取当前主题
@@ -201,8 +203,12 @@ export function PtyTerminal({
   // runner/workdir 切换会通过 key 触发卸载；这里顺手停掉旧 PTY，避免旧 CLI 抢到下一条输入。
   useEffect(() => {
     return () => {
-      if (!startedRef.current) return;
-      invoke("stop_pty_session", { sessionId }).catch(() => {});
+      if (!startedRef.current && !startingRef.current) return;
+      startingRef.current = false;
+      launchTokenRef.current += 1;
+      if (startedRef.current) {
+        invoke("stop_pty_session", { sessionId }).catch(() => {});
+      }
     };
   }, [sessionId]);
 
@@ -281,6 +287,8 @@ export function PtyTerminal({
         termRef.current?.writeln("\x1b[90m[进程已退出]\x1b[0m");
         setExited(true);
         startedRef.current = false; // 允许重启
+        startingRef.current = false;
+        launchTokenRef.current += 1;
       }
     );
 
@@ -353,12 +361,15 @@ export function PtyTerminal({
   };
 
   useEffect(() => {
-    if (!active || startedRef.current) return;
-    startedRef.current = true;
+    if (!active || startedRef.current || startingRef.current) return;
+    startingRef.current = true;
     setExited(false);
+    const launchToken = launchTokenRef.current + 1;
+    launchTokenRef.current = launchToken;
 
     // 延迟 250ms：等 resize_popup_full 动画完成，容器达到目标尺寸
     const timer = setTimeout(() => {
+      if (launchTokenRef.current !== launchToken) return;
       const fit = fitRef.current;
       const term = termRef.current;
       if (fit) fit.fit();
@@ -383,21 +394,34 @@ export function PtyTerminal({
         env: envRef.current ?? null,
       })
         .then(() => {
+          if (launchTokenRef.current !== launchToken) return;
+          startedRef.current = true;
+          startingRef.current = false;
           // spawn 返回 = CLI 进程已启动（resolve_command_path 保证是完整路径直接 spawn）
           onReadyRef.current?.();
         })
         .catch((e) => {
+          if (launchTokenRef.current !== launchToken) return;
+          startingRef.current = false;
+          startedRef.current = false;
           termRef.current?.writeln(`\x1b[31m启动失败: ${e}\x1b[0m`);
         });
     }, 250);
 
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      if (launchTokenRef.current === launchToken && !startedRef.current) {
+        startingRef.current = false;
+      }
+    };
   }, [active, sessionId, workdir, command]);
 
   // ── 重新启动（退出后用户点击重启）───────────────────────
   const handleRestart = () => {
     setExited(false);
     startedRef.current = false;
+    startingRef.current = false;
+    launchTokenRef.current += 1;
     termRef.current?.clear();
 
     const fit = fitRef.current;
@@ -405,7 +429,9 @@ export function PtyTerminal({
     if (fit) fit.fit();
     const cols = Math.max(term?.cols ?? 80, 40);
     const rows = Math.max(term?.rows ?? 24, 12);
-    startedRef.current = true;
+    startingRef.current = true;
+    const launchToken = launchTokenRef.current + 1;
+    launchTokenRef.current = launchToken;
 
     const displayCmd = [command, ...argsRef.current].join(" ");
     term?.writeln(`\x1b[90m$ ${displayCmd}\x1b[0m`);
@@ -420,9 +446,15 @@ export function PtyTerminal({
       env: envRef.current ?? null,
     })
       .then(() => {
+        if (launchTokenRef.current !== launchToken) return;
+        startedRef.current = true;
+        startingRef.current = false;
         onReadyRef.current?.();
       })
       .catch((e) => {
+        if (launchTokenRef.current !== launchToken) return;
+        startedRef.current = false;
+        startingRef.current = false;
         termRef.current?.writeln(`\x1b[31m启动失败: ${e}\x1b[0m`);
       });
   };

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -516,6 +516,8 @@ export function SessionList() {
     }
   };
 
+  if (!activeWorkspace) return null;
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
       {/* 区域头 */}
@@ -567,8 +569,6 @@ export function SessionList() {
         </button>
       </div>
 
-      {activeWorkspace ? (
-        <>
           {/* Session 列表 */}
           <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
             <SortableContext items={wsSessions.map((s) => s.id)} strategy={verticalListSortingStrategy}>
@@ -598,22 +598,7 @@ export function SessionList() {
             </SortableContext>
           </DndContext>
 
-          {wsSessions.length === 0 && (
-            <div
-              style={{
-              textAlign: "center", padding: "22px 0 12px",
-              color: "var(--ci-text-dim)", fontSize: 12,
-              border: "1px dashed var(--ci-pill-border)",
-              borderRadius: 18,
-              background: "var(--ci-panel-grad)",
-              boxShadow: "var(--ci-inset-highlight), var(--ci-card-shadow)",
-              textShadow,
-            }}>
-              点击「+ 新建」开始新会话
-            </div>
-          )}
-        </>
-      ) : (
+      {wsSessions.length === 0 && (
         <div
           style={{
           textAlign: "center", padding: "22px 0 12px",
@@ -624,7 +609,7 @@ export function SessionList() {
           boxShadow: "var(--ci-inset-highlight), var(--ci-card-shadow)",
           textShadow,
         }}>
-          先创建一个 Workspace 再开始会话
+          点击「+ 新建」开始新会话
         </div>
       )}
     </div>

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -448,12 +448,11 @@ export function SessionList() {
   const isGlass = useSettingsStore((s) => isGlassTheme(s.settings.theme));
   const textShadow = isGlass ? "var(--ci-glass-text-shadow)" : "none";
 
-  if (!activeWorkspace) return null;
-
-  const accentColor = getWorkspaceColor(activeWorkspace.color);
+  const accentColor = activeWorkspace ? getWorkspaceColor(activeWorkspace.color) : "var(--ci-accent)";
   const wsSessions = useMemo(() => {
+    if (!activeWorkspace) return [];
     return orderWorkspaceSessions(sessions, activeWorkspace.id, sessionOrderByWorkspace);
-  }, [sessions, activeWorkspaceId, sessionOrderByWorkspace]);
+  }, [activeWorkspace, sessions, sessionOrderByWorkspace]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
@@ -461,6 +460,7 @@ export function SessionList() {
   );
 
   const handleDragEnd = (event: DragEndEvent) => {
+    if (!activeWorkspace) return;
     const { active, over } = event;
     if (!over || active.id === over.id) return;
 
@@ -472,6 +472,7 @@ export function SessionList() {
   };
 
   const handleNewSession = async () => {
+    if (!activeWorkspace) return;
     const id = addSession(activeWorkspace.id, activeWorkspace.path, undefined, { ...runner });
     setExpandedSession(id);
 
@@ -566,36 +567,53 @@ export function SessionList() {
         </button>
       </div>
 
-      {/* Session 列表 */}
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-        <SortableContext items={wsSessions.map((s) => s.id)} strategy={verticalListSortingStrategy}>
-          <AnimatePresence>
-            {wsSessions.map((session) => (
-              <SortableSessionCard key={session.id} id={session.id}>
-                <SessionCard
-                  session={session}
-                  isActive={session.id === activeSessionId}
-                  accentColor={accentColor}
-                  isGlass={isGlass}
-                  onClick={() => setActiveSession(session.id)}
-                  onExpand={() => {
-                    setActiveSession(session.id);
-                    setExpandedSession(session.id);
-                  }}
-                  onRemove={() => handleRemoveSession(session)}
-                  onRotateSuspend={() => {
-                    updateSession(session.id, {
-                      status: session.status === "waiting" ? "suspended" : "waiting",
-                    });
-                  }}
-                />
-              </SortableSessionCard>
-            ))}
-          </AnimatePresence>
-        </SortableContext>
-      </DndContext>
+      {activeWorkspace ? (
+        <>
+          {/* Session 列表 */}
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+            <SortableContext items={wsSessions.map((s) => s.id)} strategy={verticalListSortingStrategy}>
+              <AnimatePresence>
+                {wsSessions.map((session) => (
+                  <SortableSessionCard key={session.id} id={session.id}>
+                    <SessionCard
+                      session={session}
+                      isActive={session.id === activeSessionId}
+                      accentColor={accentColor}
+                      isGlass={isGlass}
+                      onClick={() => setActiveSession(session.id)}
+                      onExpand={() => {
+                        setActiveSession(session.id);
+                        setExpandedSession(session.id);
+                      }}
+                      onRemove={() => handleRemoveSession(session)}
+                      onRotateSuspend={() => {
+                        updateSession(session.id, {
+                          status: session.status === "waiting" ? "suspended" : "waiting",
+                        });
+                      }}
+                    />
+                  </SortableSessionCard>
+                ))}
+              </AnimatePresence>
+            </SortableContext>
+          </DndContext>
 
-      {wsSessions.length === 0 && (
+          {wsSessions.length === 0 && (
+            <div
+              style={{
+              textAlign: "center", padding: "22px 0 12px",
+              color: "var(--ci-text-dim)", fontSize: 12,
+              border: "1px dashed var(--ci-pill-border)",
+              borderRadius: 18,
+              background: "var(--ci-panel-grad)",
+              boxShadow: "var(--ci-inset-highlight), var(--ci-card-shadow)",
+              textShadow,
+            }}>
+              点击「+ 新建」开始新会话
+            </div>
+          )}
+        </>
+      ) : (
         <div
           style={{
           textAlign: "center", padding: "22px 0 12px",
@@ -606,7 +624,7 @@ export function SessionList() {
           boxShadow: "var(--ci-inset-highlight), var(--ci-card-shadow)",
           textShadow,
         }}>
-          点击「+ 新建」开始新会话
+          先创建一个 Workspace 再开始会话
         </div>
       )}
     </div>

--- a/src/store/sessionStore.ts
+++ b/src/store/sessionStore.ts
@@ -172,6 +172,10 @@ export const useSessionStore = create<SessionStore>()(
             state.activeSessionId === id
               ? (sessions[0]?.id ?? null)
               : state.activeSessionId;
+          const expandedSessionId =
+            state.expandedSessionId === id
+              ? null
+              : state.expandedSessionId;
           const worktreeReadyIds = new Set(state.worktreeReadyIds);
           worktreeReadyIds.delete(id);
           const sessionOrderByWorkspace = Object.fromEntries(
@@ -180,7 +184,7 @@ export const useSessionStore = create<SessionStore>()(
               ids.filter((sid) => sid !== id),
             ])
           );
-          return { sessions, activeSessionId, worktreeReadyIds, sessionOrderByWorkspace };
+          return { sessions, activeSessionId, expandedSessionId, worktreeReadyIds, sessionOrderByWorkspace };
         }),
 
       setActiveSession: (id) =>
@@ -226,13 +230,17 @@ export const useSessionStore = create<SessionStore>()(
             state.sessions.find((s) => s.id === state.activeSessionId)?.workspaceId === workspaceId
               ? (sessions[0]?.id ?? null)
               : state.activeSessionId;
+          const expandedSessionId =
+            state.sessions.find((s) => s.id === state.expandedSessionId)?.workspaceId === workspaceId
+              ? null
+              : state.expandedSessionId;
           const removedIds = state.sessions
             .filter((s) => s.workspaceId === workspaceId)
             .map((s) => s.id);
           const worktreeReadyIds = new Set(state.worktreeReadyIds);
           removedIds.forEach((id) => worktreeReadyIds.delete(id));
           const { [workspaceId]: _, ...restOrder } = state.sessionOrderByWorkspace;
-          return { sessions, activeSessionId, worktreeReadyIds, sessionOrderByWorkspace: restOrder };
+          return { sessions, activeSessionId, expandedSessionId, worktreeReadyIds, sessionOrderByWorkspace: restOrder };
         }),
 
       markWorktreeReady: (id) =>


### PR DESCRIPTION

  ## Summary                                                                          
                                                                                   
  - keep `SessionList` hook execution stable when there is no active workspace        
  - clear `expandedSessionId` when deleting the expanded session or removing all   
  sessions in a workspace           
  - prevent the app from blanking when all workspaces are removed or when creating the
   first workspace after an empty state                                               
                                                                                      
  ## What was happening                                                               
                                                                                      
  There were two separate blank-screen paths:                                      
                                                                                      
  1. `SessionList` changed its hook execution path depending on whether            
  `activeWorkspace` existed, which could trigger a React hook-order crash during `0 ↔ 
   1 workspace` transitions.                                                       
  2. `expandedSessionId` could remain set after deleting the expanded session or      
  deleting an entire workspace, leaving the app in subpage mode with no panel to
  render.                                                                             
                                                                                   
  ## Result                                                                           
                                                                                   
  Deleting all workspaces and creating the first workspace from an empty state now    
  keeps the UI in a valid, non-blank state.