### PR TITLE
修复会话记录丢失问题（localstorage）

### DIFF
--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path};
 
-use crate::util::{background_command, expand_path};
+use crate::util::{background_command, expand_path, normalize_expanded_path};
 
 // ── 辅助函数 ──────────────────────────────────────────────────────
 
@@ -321,7 +321,7 @@ pub async fn prune_orphan_worktrees(
         // 规范化已知路径集合
         let known: std::collections::HashSet<String> = known_worktree_paths
             .iter()
-            .map(|p| expand_path(p).trim_end_matches('/').to_string())
+            .map(|p| normalize_expanded_path(p))
             .collect();
 
         let mut pruned = vec![];
@@ -332,7 +332,7 @@ pub async fn prune_orphan_worktrees(
                 continue;
             }
 
-            let canonical = path.to_string_lossy().trim_end_matches('/').to_string();
+            let canonical = normalize_expanded_path(path.to_string_lossy().as_ref());
             if known.contains(&canonical) {
                 continue;
             }

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -1,9 +1,9 @@
 use std::{fs, path::Path};
 
+use crate::runtime_scope::session_worktree_root_dir;
 use crate::util::{background_command, expand_path, normalize_expanded_path};
 
 // ── 辅助函数 ──────────────────────────────────────────────────────
-
 /// 从 worktree 目录的 HEAD 文件读取分支名
 pub fn read_worktree_branch(worktree_path: &Path) -> Option<String> {
     // worktree 中的 HEAD 格式：ref: refs/heads/<branch>
@@ -218,14 +218,16 @@ pub async fn setup_session_worktree(
             return Ok(None); // detached HEAD，跳过
         }
 
-        // 计算 worktree 路径（放在 repo 同级的 .code-bar-worktrees/）
+        // 计算 worktree 路径（放在 repo 同级的 session worktree 根目录）
         let repo_parent = Path::new(&expanded_workdir)
             .parent()
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_else(|| expanded_workdir.clone());
         let worktree_path = format!(
-            "{}/.code-bar-worktrees/session-{}",
-            repo_parent, session_id_clone
+            "{}/{}/session-{}",
+            repo_parent,
+            session_worktree_root_dir(),
+            session_id_clone
         );
         let branch = format!("ci/session-{}", session_id_clone);
 
@@ -311,7 +313,7 @@ pub async fn prune_orphan_worktrees(
             .parent()
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_else(|| expanded_workdir.clone());
-        let wt_base = format!("{}/.code-bar-worktrees", repo_parent);
+        let wt_base = format!("{}/{}", repo_parent, session_worktree_root_dir());
         let wt_base_path = Path::new(&wt_base);
 
         if !wt_base_path.exists() {

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -239,11 +239,29 @@ fn hook_specs(source: HookSource) -> Result<Vec<HookCommandSpec>, String> {
 }
 
 #[cfg(unix)]
-fn managed_legacy_commands(source: HookSource) -> &'static [&'static str] {
+fn managed_legacy_commands(source: HookSource) -> Vec<String> {
+    let mut commands = Vec::new();
     match source {
-        HookSource::ClaudeCode => &["nc -U /tmp/code-bar-hook.sock"],
-        HookSource::Codex => &[],
+        HookSource::ClaudeCode => {
+            commands.push("nc -U /tmp/code-bar-hook.sock".to_string());
+            commands.push("/tmp/code-bar-hook-claude.sock".to_string());
+            commands.push(
+                crate::util::codebar_runtime_dir()
+                    .join("code-bar-hook-claude.sock")
+                    .to_string_lossy()
+                    .to_string(),
+            );
+        }
+        HookSource::Codex => {
+            commands.push(
+                crate::util::codebar_runtime_dir()
+                    .join("code-bar-hook-codex.sock")
+                    .to_string_lossy()
+                    .to_string(),
+            );
+        }
     }
+    commands
 }
 
 fn is_managed_command(command: &str, source: HookSource) -> bool {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod keystore;
 mod notification;
 mod provider_sessions;
 mod pty;
+mod runtime_scope;
 mod runner;
 mod session_lifecycle;
 mod state;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod pty;
 mod runner;
 mod session_lifecycle;
 mod state;
+mod ui_state;
 mod util;
 mod window;
 
@@ -241,6 +242,13 @@ pub fn run() {
             hooks::trust_workspace,
             // 支持点击回调的原生通知（macOS 常驻等待 + click callback）
             notification::send_notification_with_callback,
+            ui_state::load_ui_states,
+            ui_state::load_deleted_ui_state,
+            ui_state::mark_deleted_items,
+            ui_state::clear_deleted_items,
+            ui_state::save_ui_state,
+            ui_state::remove_ui_state,
+            ui_state::recover_workspace_sessions,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -249,6 +249,7 @@ pub fn run() {
             ui_state::save_ui_state,
             ui_state::remove_ui_state,
             ui_state::recover_workspace_sessions,
+            ui_state::save_recovery_binding,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/notification.rs
+++ b/src-tauri/src/notification.rs
@@ -12,7 +12,6 @@
 #[cfg(target_os = "macos")]
 pub mod macos {
     use std::sync::OnceLock;
-    use tauri_plugin_notification::NotificationExt;
 
     static MAC_NOTIFICATION_APP_INIT: OnceLock<Result<(), String>> = OnceLock::new();
 
@@ -41,17 +40,12 @@ pub mod macos {
                 set_application(&bundle_id).map_err(|e| e.to_string())
             });
             if let Err(e) = init_result {
+                // dev 场景下临时 identifier 可能未注册到 LaunchServices，
+                // set_application 会失败。此时继续使用 mac_notification_sys
+                // 发送通知（系统会回退到默认 app），仍可保留点击回调能力。
                 eprintln!(
-                    "[notification] set_application({bundle_id}) 失败，降级到 tauri plugin: {e}"
+                    "[notification] set_application({bundle_id}) 失败，继续使用默认 app 发送通知: {e}"
                 );
-                let mut builder = app.notification().builder().title(&title).body(&body);
-                if sound {
-                    builder = builder.sound("default");
-                }
-                if let Err(show_err) = builder.show() {
-                    eprintln!("[notification] fallback send 失败: {show_err}");
-                }
-                return;
             }
 
             // 使用 Notification builder API：

--- a/src-tauri/src/runtime_scope.rs
+++ b/src-tauri/src/runtime_scope.rs
@@ -1,0 +1,19 @@
+pub const UI_STATE_NAMESPACE_DEV: &str = "dev";
+pub const WORKTREE_ROOT_DIR: &str = ".code-bar-worktrees";
+pub const WORKTREE_ROOT_DIR_DEV: &str = ".code-bar-worktrees-dev";
+
+pub fn ui_state_namespace_dir() -> Option<&'static str> {
+    if cfg!(debug_assertions) {
+        Some(UI_STATE_NAMESPACE_DEV)
+    } else {
+        None
+    }
+}
+
+pub fn session_worktree_root_dir() -> &'static str {
+    if cfg!(debug_assertions) {
+        WORKTREE_ROOT_DIR_DEV
+    } else {
+        WORKTREE_ROOT_DIR
+    }
+}

--- a/src-tauri/src/ui_state.rs
+++ b/src-tauri/src/ui_state.rs
@@ -3,7 +3,7 @@ use std::{
     fs,
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
-    time::UNIX_EPOCH,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use serde::{Deserialize, Serialize};
@@ -13,6 +13,7 @@ use crate::util::{background_command, home_dir, normalize_expanded_path};
 
 const UI_STATE_DIR: &str = "ui-state";
 const DELETED_UI_STATE_KEY: &str = "code-bar-deleted-items";
+const RECOVERY_BINDINGS_KEY: &str = "code-bar-recovery-bindings";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -96,6 +97,18 @@ pub struct DeleteWorkspaceInput {
     path: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RecoveryBinding {
+    session_id: String,
+    runner_type: String,
+    provider_session_id: String,
+    #[serde(default)]
+    worktree_path: Option<String>,
+    #[serde(default)]
+    updated_at_ms: u64,
+}
+
 fn normalize_optional_string(value: Option<String>) -> Option<String> {
     value
         .map(|value| value.trim().to_string())
@@ -104,6 +117,33 @@ fn normalize_optional_string(value: Option<String>) -> Option<String> {
 
 fn normalize_path(value: Option<String>) -> Option<String> {
     normalize_optional_string(value).map(|path| normalize_expanded_path(&path))
+}
+
+impl RecoveryBinding {
+    fn normalized(self) -> Option<Self> {
+        let session_id = self.session_id.trim().to_string();
+        let runner_type = self.runner_type.trim().to_string();
+        let provider_session_id = self.provider_session_id.trim().to_string();
+        if session_id.is_empty() || runner_type.is_empty() || provider_session_id.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            session_id,
+            runner_type,
+            provider_session_id,
+            worktree_path: normalize_path(self.worktree_path),
+            updated_at_ms: if self.updated_at_ms == 0 {
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .ok()
+                    .map(|duration| duration.as_millis() as u64)
+                    .unwrap_or(0)
+            } else {
+                self.updated_at_ms
+            },
+        })
+    }
 }
 
 impl DeletedSessionRef {
@@ -287,6 +327,51 @@ fn write_deleted_ui_state(app: &tauri::AppHandle, state: &DeletedUiState) -> Res
     let payload = serde_json::to_string(&normalize_deleted_ui_state(state.clone()))
         .map_err(|e| format!("序列化已删除 UI 状态失败: {e}"))?;
     write_ui_state(app, DELETED_UI_STATE_KEY, &payload)
+}
+
+fn read_recovery_bindings(app: &tauri::AppHandle) -> Result<Vec<RecoveryBinding>, String> {
+    let Some(content) = read_ui_state(app, RECOVERY_BINDINGS_KEY)? else {
+        return Ok(Vec::new());
+    };
+
+    serde_json::from_str::<Vec<RecoveryBinding>>(&content)
+        .map(|items| items.into_iter().filter_map(RecoveryBinding::normalized).collect())
+        .map_err(|e| format!("解析恢复绑定失败: {e}"))
+}
+
+fn write_recovery_bindings(app: &tauri::AppHandle, bindings: &[RecoveryBinding]) -> Result<(), String> {
+    if bindings.is_empty() {
+        return remove_ui_state_file(app, RECOVERY_BINDINGS_KEY);
+    }
+
+    let payload = serde_json::to_string(bindings)
+        .map_err(|e| format!("序列化恢复绑定失败: {e}"))?;
+    write_ui_state(app, RECOVERY_BINDINGS_KEY, &payload)
+}
+
+fn upsert_recovery_binding(app: &tauri::AppHandle, binding: RecoveryBinding) -> Result<(), String> {
+    let Some(binding) = binding.normalized() else {
+        return Ok(());
+    };
+
+    let mut bindings = read_recovery_bindings(app)?;
+    bindings.retain(|entry| entry.session_id != binding.session_id);
+    bindings.push(binding);
+    bindings.sort_by(|a, b| a.session_id.cmp(&b.session_id));
+    write_recovery_bindings(app, &bindings)
+}
+
+fn remove_recovery_bindings_by_session_ids(
+    app: &tauri::AppHandle,
+    session_ids: &HashSet<String>,
+) -> Result<(), String> {
+    if session_ids.is_empty() {
+        return Ok(());
+    }
+
+    let mut bindings = read_recovery_bindings(app)?;
+    bindings.retain(|entry| !session_ids.contains(&entry.session_id));
+    write_recovery_bindings(app, &bindings)
 }
 
 fn modified_millis(path: &Path) -> u64 {
@@ -504,10 +589,11 @@ fn extract_codex_first_task(json: &serde_json::Value) -> Option<String> {
     None
 }
 
-fn latest_codex_hint(worktree_path: &Path) -> Option<RecoveryHint> {
-    let sessions_dir = home_dir()?.join(".codex").join("sessions");
-    let target_workdir = normalize_expanded_path(&worktree_path.to_string_lossy());
-    let mut best: Option<RecoveryHint> = None;
+fn load_codex_history_index() -> HashMap<String, RecoveryHint> {
+    let Some(sessions_dir) = home_dir().map(|home| home.join(".codex").join("sessions")) else {
+        return HashMap::new();
+    };
+    let mut hints = HashMap::new();
     let mut stack = vec![sessions_dir];
 
     while let Some(dir) = stack.pop() {
@@ -573,31 +659,49 @@ fn latest_codex_hint(worktree_path: &Path) -> Option<RecoveryHint> {
                 continue;
             }
 
-            if normalize_expanded_path(&cwd) != target_workdir {
-                continue;
+            let normalized_cwd = normalize_expanded_path(&cwd);
+            let candidate = RecoveryHint {
+                runner_type: "codex".to_string(),
+                provider_session_id,
+                current_task: first_task,
+                modified_at_ms: modified_millis(&path),
+            };
+            let slot = hints.entry(normalized_cwd).or_insert_with(|| candidate.clone());
+            if slot.modified_at_ms < candidate.modified_at_ms {
+                *slot = candidate;
             }
-
-            select_newer_hint(
-                &mut best,
-                RecoveryHint {
-                    runner_type: "codex".to_string(),
-                    provider_session_id,
-                    current_task: first_task,
-                    modified_at_ms: modified_millis(&path),
-                },
-            );
         }
     }
 
-    best
+    hints
 }
 
-fn latest_recovery_hint(session_id: &str, worktree_path: &Path) -> Option<RecoveryHint> {
-    let mut best = latest_claude_hint(session_id);
-    if let Some(codex_hint) = latest_codex_hint(worktree_path) {
-        select_newer_hint(&mut best, codex_hint);
+fn resolve_recovery_hint(
+    session_id: &str,
+    worktree_path: &Path,
+    recovery_bindings: &HashMap<String, RecoveryBinding>,
+    codex_history: &HashMap<String, RecoveryHint>,
+) -> Option<RecoveryHint> {
+    let worktree_key = normalize_expanded_path(&worktree_path.to_string_lossy());
+    if let Some(binding) = recovery_bindings.get(session_id) {
+        if binding.runner_type == "claude-code" {
+            let mut hint = latest_claude_hint(session_id)?;
+            hint.provider_session_id = binding.provider_session_id.clone();
+            hint.modified_at_ms = hint.modified_at_ms.max(binding.updated_at_ms);
+            return Some(hint);
+        }
+
+        if binding.runner_type == "codex" {
+            let mut hint = codex_history.get(&worktree_key).cloned()?;
+            if hint.provider_session_id != binding.provider_session_id {
+                return None;
+            }
+            hint.modified_at_ms = hint.modified_at_ms.max(binding.updated_at_ms);
+            return Some(hint);
+        }
     }
-    best
+
+    latest_claude_hint(session_id)
 }
 
 fn numeric_session_id(name: &str) -> Option<String> {
@@ -631,9 +735,36 @@ pub fn remove_ui_state(app: tauri::AppHandle, key: String) -> Result<(), String>
     remove_ui_state_file(&app, &key)
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SaveRecoveryBindingInput {
+    session_id: String,
+    runner_type: String,
+    provider_session_id: String,
+    #[serde(default)]
+    worktree_path: Option<String>,
+}
+
 #[tauri::command]
 pub fn load_deleted_ui_state(app: tauri::AppHandle) -> Result<DeletedUiState, String> {
     read_deleted_ui_state(&app)
+}
+
+#[tauri::command]
+pub fn save_recovery_binding(
+    app: tauri::AppHandle,
+    input: SaveRecoveryBindingInput,
+) -> Result<(), String> {
+    upsert_recovery_binding(
+        &app,
+        RecoveryBinding {
+            session_id: input.session_id,
+            runner_type: input.runner_type,
+            provider_session_id: input.provider_session_id,
+            worktree_path: input.worktree_path,
+            updated_at_ms: 0,
+        },
+    )
 }
 
 #[tauri::command]
@@ -723,6 +854,7 @@ pub fn clear_deleted_items(
         .retain(|id| !removed_session_ids.contains(id));
     state.workspace_ids
         .retain(|id| !removed_workspace_ids.contains(id));
+    remove_recovery_bindings_by_session_ids(&app, &removed_session_ids)?;
     state.sessions.retain(|entry| {
         !removed_session_refs
             .iter()
@@ -745,94 +877,117 @@ pub fn clear_deleted_items(
     }
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecoverWorkspaceInput {
+    workspace_id: String,
+    workspace_path: String,
+}
+
 #[tauri::command]
 pub fn recover_workspace_sessions(
     app: tauri::AppHandle,
-    workspace_id: String,
-    workspace_path: String,
+    workspaces: Vec<RecoverWorkspaceInput>,
     existing_session_ids: Vec<String>,
 ) -> Result<Vec<RecoveredSession>, String> {
-    let normalized_workspace_path = normalize_path(Some(workspace_path)).unwrap_or_default();
-    let repo_root = PathBuf::from(&normalized_workspace_path);
-    let Some(parent) = repo_root.parent() else {
-        return Ok(vec![]);
-    };
-
-    let worktree_root = parent.join(".code-bar-worktrees");
-    if !worktree_root.exists() {
+    if workspaces.is_empty() {
         return Ok(vec![]);
     }
 
     let deleted_state = read_deleted_ui_state(&app)?;
+    let recovery_bindings = read_recovery_bindings(&app)?
+        .into_iter()
+        .map(|binding| (binding.session_id.clone(), binding))
+        .collect::<HashMap<_, _>>();
+    let codex_history = load_codex_history_index();
     let existing = existing_session_ids.into_iter().collect::<HashSet<_>>();
-    let base_branch = default_base_branch(&repo_root);
     let mut recovered = Vec::new();
 
-    for entry in fs::read_dir(&worktree_root)
-        .map_err(|e| format!("读取 {} 失败: {e}", worktree_root.display()))?
-        .flatten()
-    {
-        let worktree_path = entry.path();
-        if !worktree_path.is_dir() {
+    for workspace in workspaces {
+        let normalized_workspace_path = normalize_path(Some(workspace.workspace_path)).unwrap_or_default();
+        let repo_root = PathBuf::from(&normalized_workspace_path);
+        let Some(parent) = repo_root.parent() else {
+            continue;
+        };
+
+        let worktree_root = parent.join(".code-bar-worktrees");
+        if !worktree_root.exists() {
             continue;
         }
 
-        let Some(dir_name) = worktree_path.file_name().and_then(|name| name.to_str()) else {
-            continue;
-        };
-        let Some(session_id) = numeric_session_id(dir_name) else {
-            continue;
-        };
-        if existing.contains(&session_id) || deleted_state.session_ids.contains(&session_id) {
-            continue;
-        }
-        if deleted_state
-            .sessions
-            .iter()
-            .any(|entry| entry.matches(&session_id, Some(&workspace_id)))
+        let base_branch = default_base_branch(&repo_root);
+
+        for entry in fs::read_dir(&worktree_root)
+            .map_err(|e| format!("读取 {} 失败: {e}", worktree_root.display()))?
+            .flatten()
         {
-            continue;
-        }
-        if deleted_state.workspace_ids.contains(&workspace_id)
-            || deleted_state
-                .workspaces
+            let worktree_path = entry.path();
+            if !worktree_path.is_dir() {
+                continue;
+            }
+
+            let Some(dir_name) = worktree_path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            let Some(session_id) = numeric_session_id(dir_name) else {
+                continue;
+            };
+            if existing.contains(&session_id) || deleted_state.session_ids.contains(&session_id) {
+                continue;
+            }
+            if deleted_state
+                .sessions
                 .iter()
-                .any(|entry| entry.matches(&workspace_id, Some(&normalized_workspace_path)))
-        {
-            continue;
+                .any(|entry| entry.matches(&session_id, Some(&workspace.workspace_id)))
+            {
+                continue;
+            }
+            if deleted_state.workspace_ids.contains(&workspace.workspace_id)
+                || deleted_state
+                    .workspaces
+                    .iter()
+                    .any(|entry| entry.matches(&workspace.workspace_id, Some(&normalized_workspace_path)))
+            {
+                continue;
+            }
+
+            let Some(hint) = resolve_recovery_hint(
+                &session_id,
+                &worktree_path,
+                &recovery_bindings,
+                &codex_history,
+            ) else {
+                continue;
+            };
+
+            let branch_name = current_branch(&worktree_path)
+                .or_else(|| Some(format!("ci/session-{session_id}")));
+            let workdir = worktree_path.to_string_lossy().to_string();
+            let current_task = hint.current_task.clone();
+
+            recovered.push(RecoveredSession {
+                id: session_id.clone(),
+                name: normalize_task_title(&current_task, &session_id),
+                workspace_id: workspace.workspace_id.clone(),
+                workdir: workdir.clone(),
+                status: "idle".to_string(),
+                current_task,
+                created_at: modified_millis(&worktree_path),
+                diff_files: vec![],
+                output: vec![],
+                runner: RecoveredRunnerConfig {
+                    r#type: hint.runner_type,
+                    cli_path: String::new(),
+                    cli_args: String::new(),
+                    api_base_url: String::new(),
+                    api_key_override: String::new(),
+                },
+                branch_name,
+                base_branch: base_branch.clone(),
+                worktree_path: Some(workdir),
+                provider_session_id: Some(hint.provider_session_id),
+            });
         }
-
-        let Some(hint) = latest_recovery_hint(&session_id, &worktree_path) else {
-            continue;
-        };
-
-        let branch_name =
-            current_branch(&worktree_path).or_else(|| Some(format!("ci/session-{session_id}")));
-        let workdir = worktree_path.to_string_lossy().to_string();
-        let current_task = hint.current_task.clone();
-
-        recovered.push(RecoveredSession {
-            id: session_id.clone(),
-            name: normalize_task_title(&current_task, &session_id),
-            workspace_id: workspace_id.clone(),
-            workdir: workdir.clone(),
-            status: "idle".to_string(),
-            current_task,
-            created_at: modified_millis(&worktree_path),
-            diff_files: vec![],
-            output: vec![],
-            runner: RecoveredRunnerConfig {
-                r#type: hint.runner_type,
-                cli_path: String::new(),
-                cli_args: String::new(),
-                api_base_url: String::new(),
-                api_key_override: String::new(),
-            },
-            branch_name,
-            base_branch: base_branch.clone(),
-            worktree_path: Some(workdir),
-            provider_session_id: Some(hint.provider_session_id),
-        });
     }
 
     recovered.sort_by_key(|session| session.id.parse::<u64>().unwrap_or(u64::MAX));

--- a/src-tauri/src/ui_state.rs
+++ b/src-tauri/src/ui_state.rs
@@ -9,6 +9,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 use tauri::Manager;
 
+use crate::runtime_scope::{session_worktree_root_dir, ui_state_namespace_dir};
 use crate::util::{background_command, home_dir, normalize_expanded_path};
 
 const UI_STATE_DIR: &str = "ui-state";
@@ -279,7 +280,13 @@ fn ui_state_file(app: &tauri::AppHandle, key: &str) -> Result<PathBuf, String> {
 
     app.path()
         .app_data_dir()
-        .map(|dir| dir.join(UI_STATE_DIR).join(format!("{sanitized}.json")))
+        .map(|dir| {
+            let mut state_dir = dir.join(UI_STATE_DIR);
+            if let Some(namespace) = ui_state_namespace_dir() {
+                state_dir = state_dir.join(namespace);
+            }
+            state_dir.join(format!("{sanitized}.json"))
+        })
         .map_err(|e| format!("无法解析 UI 状态目录: {e}"))
 }
 
@@ -521,8 +528,10 @@ fn latest_claude_hint(session_id: &str) -> Option<RecoveryHint> {
                 }
             }
 
+            // 有些 Claude 会话在未成功发起首条 query 前也会落盘 session 文件。
+            // 这种场景下仍然应该可恢复，任务标题退化为通用文案。
             if first_task.is_empty() {
-                continue;
+                first_task = "继续会话".to_string();
             }
 
             select_newer_hint(
@@ -910,7 +919,7 @@ pub fn recover_workspace_sessions(
             continue;
         };
 
-        let worktree_root = parent.join(".code-bar-worktrees");
+        let worktree_root = parent.join(session_worktree_root_dir());
         if !worktree_root.exists() {
             continue;
         }

--- a/src-tauri/src/ui_state.rs
+++ b/src-tauri/src/ui_state.rs
@@ -1,0 +1,450 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+    time::UNIX_EPOCH,
+};
+
+use serde::{Deserialize, Serialize};
+use tauri::Manager;
+
+use crate::util::{background_command, expand_path, home_dir};
+
+const UI_STATE_DIR: &str = "ui-state";
+const DELETED_UI_STATE_KEY: &str = "code-bar-deleted-items";
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RecoveredRunnerConfig {
+    r#type: String,
+    cli_path: String,
+    cli_args: String,
+    api_base_url: String,
+    api_key_override: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecoveredSession {
+    id: String,
+    name: String,
+    workspace_id: String,
+    workdir: String,
+    status: String,
+    current_task: String,
+    created_at: u64,
+    diff_files: Vec<serde_json::Value>,
+    output: Vec<String>,
+    runner: RecoveredRunnerConfig,
+    branch_name: Option<String>,
+    base_branch: Option<String>,
+    worktree_path: Option<String>,
+    provider_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ClaudeSessionHint {
+    provider_session_id: String,
+    current_task: String,
+    modified_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeletedUiState {
+    session_ids: Vec<String>,
+    workspace_ids: Vec<String>,
+}
+
+fn ui_state_file(app: &tauri::AppHandle, key: &str) -> Result<PathBuf, String> {
+    let sanitized = key
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+
+    app.path()
+        .app_data_dir()
+        .map(|dir| dir.join(UI_STATE_DIR).join(format!("{sanitized}.json")))
+        .map_err(|e| format!("无法解析 UI 状态目录: {e}"))
+}
+
+fn read_ui_state(app: &tauri::AppHandle, key: &str) -> Result<Option<String>, String> {
+    let path = ui_state_file(app, key)?;
+    match fs::read_to_string(&path) {
+        Ok(content) => Ok(Some(content)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!("读取 {} 失败: {e}", path.display())),
+    }
+}
+
+fn write_ui_state(app: &tauri::AppHandle, key: &str, value: &str) -> Result<(), String> {
+    let path = ui_state_file(app, key)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("创建 UI 状态目录 {} 失败: {e}", parent.display()))?;
+    }
+
+    let tmp = path.with_extension("json.tmp");
+    fs::write(&tmp, value).map_err(|e| format!("写入 {} 失败: {e}", tmp.display()))?;
+    fs::rename(&tmp, &path).map_err(|e| format!("替换 {} 失败: {e}", path.display()))
+}
+
+fn remove_ui_state_file(app: &tauri::AppHandle, key: &str) -> Result<(), String> {
+    let path = ui_state_file(app, key)?;
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!("删除 {} 失败: {e}", path.display())),
+    }
+}
+
+fn read_deleted_ui_state(app: &tauri::AppHandle) -> Result<DeletedUiState, String> {
+    let Some(content) = read_ui_state(app, DELETED_UI_STATE_KEY)? else {
+        return Ok(DeletedUiState::default());
+    };
+
+    serde_json::from_str::<DeletedUiState>(&content)
+        .map_err(|e| format!("解析已删除 UI 状态失败: {e}"))
+}
+
+fn write_deleted_ui_state(app: &tauri::AppHandle, state: &DeletedUiState) -> Result<(), String> {
+    let payload =
+        serde_json::to_string(state).map_err(|e| format!("序列化已删除 UI 状态失败: {e}"))?;
+    write_ui_state(app, DELETED_UI_STATE_KEY, &payload)
+}
+
+fn modified_millis(path: &Path) -> u64 {
+    fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn default_base_branch(repo_root: &Path) -> Option<String> {
+    for candidate in ["main", "master"] {
+        let Ok(output) = background_command("git")
+            .current_dir(repo_root)
+            .args(["rev-parse", "--verify", candidate])
+            .output()
+        else {
+            continue;
+        };
+
+        if output.status.success() {
+            return Some(candidate.to_string());
+        }
+    }
+
+    None
+}
+
+fn current_branch(path: &Path) -> Option<String> {
+    let Ok(output) = background_command("git")
+        .current_dir(path)
+        .args(["branch", "--show-current"])
+        .output()
+    else {
+        return None;
+    };
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if branch.is_empty() {
+        None
+    } else {
+        Some(branch)
+    }
+}
+
+fn normalize_task_title(task: &str, session_id: &str) -> String {
+    let trimmed = task.trim();
+    if trimmed.is_empty() {
+        return format!("会话 {session_id}");
+    }
+
+    let chars = trimmed.chars().collect::<Vec<_>>();
+    if chars.len() > 24 {
+        format!("{}…", chars[..24].iter().collect::<String>())
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn latest_claude_hint(session_id: &str) -> Option<ClaudeSessionHint> {
+    let projects_dir = home_dir()?.join(".claude").join("projects");
+    let suffix = format!("session-{session_id}");
+    let mut best: Option<ClaudeSessionHint> = None;
+
+    let Ok(project_entries) = fs::read_dir(&projects_dir) else {
+        return None;
+    };
+
+    for entry in project_entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !name.ends_with(&suffix) {
+            continue;
+        }
+
+        let Ok(files) = fs::read_dir(&path) else {
+            continue;
+        };
+
+        for file in files.flatten() {
+            let file_path = file.path();
+            if file_path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+                continue;
+            }
+
+            let provider_session_id = file_path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or_default()
+                .to_string();
+            if provider_session_id.is_empty() {
+                continue;
+            }
+
+            let Ok(handle) = fs::File::open(&file_path) else {
+                continue;
+            };
+            let reader = BufReader::new(handle);
+            let mut first_task = String::new();
+
+            for line in reader.lines().map_while(Result::ok) {
+                let Ok(json) = serde_json::from_str::<serde_json::Value>(&line) else {
+                    continue;
+                };
+
+                let is_user = json.get("type").and_then(|v| v.as_str()) == Some("user");
+                let role = json
+                    .get("message")
+                    .and_then(|message| message.get("role"))
+                    .and_then(|value| value.as_str());
+                if !is_user || role != Some("user") {
+                    continue;
+                }
+
+                let Some(content) = json
+                    .get("message")
+                    .and_then(|message| message.get("content"))
+                else {
+                    continue;
+                };
+
+                if let Some(text) = content.as_str() {
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty() && first_task.is_empty() {
+                        first_task = trimmed.to_string();
+                    }
+                }
+            }
+
+            if first_task.is_empty() {
+                continue;
+            }
+
+            let modified_at_ms = modified_millis(&file_path);
+            let candidate = ClaudeSessionHint {
+                provider_session_id,
+                current_task: first_task,
+                modified_at_ms,
+            };
+
+            if best
+                .as_ref()
+                .map(|current| current.modified_at_ms < candidate.modified_at_ms)
+                .unwrap_or(true)
+            {
+                best = Some(candidate);
+            }
+        }
+    }
+
+    best
+}
+
+fn numeric_session_id(name: &str) -> Option<String> {
+    let trimmed = name.strip_prefix("session-")?;
+    if trimmed.chars().all(|ch| ch.is_ascii_digit()) {
+        Some(trimmed.to_string())
+    } else {
+        None
+    }
+}
+
+#[tauri::command]
+pub fn load_ui_states(
+    app: tauri::AppHandle,
+    keys: Vec<String>,
+) -> Result<HashMap<String, Option<String>>, String> {
+    let mut states = HashMap::new();
+    for key in keys {
+        states.insert(key.clone(), read_ui_state(&app, &key)?);
+    }
+    Ok(states)
+}
+
+#[tauri::command]
+pub fn save_ui_state(app: tauri::AppHandle, key: String, value: String) -> Result<(), String> {
+    write_ui_state(&app, &key, &value)
+}
+
+#[tauri::command]
+pub fn remove_ui_state(app: tauri::AppHandle, key: String) -> Result<(), String> {
+    remove_ui_state_file(&app, &key)
+}
+
+#[tauri::command]
+pub fn load_deleted_ui_state(app: tauri::AppHandle) -> Result<DeletedUiState, String> {
+    read_deleted_ui_state(&app)
+}
+
+#[tauri::command]
+pub fn mark_deleted_items(
+    app: tauri::AppHandle,
+    session_ids: Vec<String>,
+    workspace_ids: Vec<String>,
+) -> Result<(), String> {
+    let mut state = read_deleted_ui_state(&app)?;
+    let mut next_session_ids = state.session_ids.into_iter().collect::<HashSet<_>>();
+    let mut next_workspace_ids = state.workspace_ids.into_iter().collect::<HashSet<_>>();
+
+    session_ids
+        .into_iter()
+        .filter(|id| !id.trim().is_empty())
+        .for_each(|id| {
+            next_session_ids.insert(id);
+        });
+    workspace_ids
+        .into_iter()
+        .filter(|id| !id.trim().is_empty())
+        .for_each(|id| {
+            next_workspace_ids.insert(id);
+        });
+
+    state.session_ids = next_session_ids.into_iter().collect();
+    state.workspace_ids = next_workspace_ids.into_iter().collect();
+    state.session_ids.sort_by_key(|id| id.parse::<u64>().unwrap_or(u64::MAX));
+    state.workspace_ids.sort();
+
+    write_deleted_ui_state(&app, &state)
+}
+
+#[tauri::command]
+pub fn clear_deleted_items(
+    app: tauri::AppHandle,
+    session_ids: Vec<String>,
+    workspace_ids: Vec<String>,
+) -> Result<(), String> {
+    let mut state = read_deleted_ui_state(&app)?;
+    let removed_session_ids = session_ids.into_iter().collect::<HashSet<_>>();
+    let removed_workspace_ids = workspace_ids.into_iter().collect::<HashSet<_>>();
+
+    state.session_ids.retain(|id| !removed_session_ids.contains(id));
+    state.workspace_ids.retain(|id| !removed_workspace_ids.contains(id));
+
+    if state.session_ids.is_empty() && state.workspace_ids.is_empty() {
+        remove_ui_state_file(&app, DELETED_UI_STATE_KEY)
+    } else {
+        write_deleted_ui_state(&app, &state)
+    }
+}
+
+#[tauri::command]
+pub fn recover_workspace_sessions(
+    app: tauri::AppHandle,
+    workspace_id: String,
+    workspace_path: String,
+    existing_session_ids: Vec<String>,
+) -> Result<Vec<RecoveredSession>, String> {
+    let repo_root = PathBuf::from(expand_path(&workspace_path));
+    let Some(parent) = repo_root.parent() else {
+        return Ok(vec![]);
+    };
+
+    let worktree_root = parent.join(".code-bar-worktrees");
+    if !worktree_root.exists() {
+        return Ok(vec![]);
+    }
+
+    let existing = existing_session_ids.into_iter().collect::<HashSet<_>>();
+    let deleted = read_deleted_ui_state(&app)?
+        .session_ids
+        .into_iter()
+        .collect::<HashSet<_>>();
+    let base_branch = default_base_branch(&repo_root);
+    let mut recovered = Vec::new();
+
+    for entry in fs::read_dir(&worktree_root)
+        .map_err(|e| format!("读取 {} 失败: {e}", worktree_root.display()))?
+        .flatten()
+    {
+        let worktree_path = entry.path();
+        if !worktree_path.is_dir() {
+            continue;
+        }
+
+        let Some(dir_name) = worktree_path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        let Some(session_id) = numeric_session_id(dir_name) else {
+            continue;
+        };
+        if existing.contains(&session_id) || deleted.contains(&session_id) {
+            continue;
+        }
+
+        let Some(claude_hint) = latest_claude_hint(&session_id) else {
+            continue;
+        };
+
+        let branch_name =
+            current_branch(&worktree_path).or_else(|| Some(format!("ci/session-{session_id}")));
+        let workdir = worktree_path.to_string_lossy().to_string();
+        let current_task = claude_hint.current_task.clone();
+
+        recovered.push(RecoveredSession {
+            id: session_id.clone(),
+            name: normalize_task_title(&current_task, &session_id),
+            workspace_id: workspace_id.clone(),
+            workdir: workdir.clone(),
+            status: "idle".to_string(),
+            current_task,
+            created_at: modified_millis(&worktree_path),
+            diff_files: vec![],
+            output: vec![],
+            runner: RecoveredRunnerConfig {
+                r#type: "claude-code".to_string(),
+                cli_path: String::new(),
+                cli_args: String::new(),
+                api_base_url: String::new(),
+                api_key_override: String::new(),
+            },
+            branch_name,
+            base_branch: base_branch.clone(),
+            worktree_path: Some(workdir),
+            provider_session_id: Some(claude_hint.provider_session_id),
+        });
+    }
+
+    recovered.sort_by_key(|session| session.id.parse::<u64>().unwrap_or(u64::MAX));
+    Ok(recovered)
+}

--- a/src-tauri/src/ui_state.rs
+++ b/src-tauri/src/ui_state.rs
@@ -9,7 +9,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 use tauri::Manager;
 
-use crate::util::{background_command, expand_path, home_dir};
+use crate::util::{background_command, home_dir, normalize_expanded_path};
 
 const UI_STATE_DIR: &str = "ui-state";
 const DELETED_UI_STATE_KEY: &str = "code-bar-deleted-items";
@@ -50,11 +50,178 @@ struct ClaudeSessionHint {
     modified_at_ms: u64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct DeletedSessionRef {
+    session_id: String,
+    #[serde(default)]
+    workspace_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct DeletedWorkspaceRef {
+    workspace_id: String,
+    #[serde(default)]
+    path: Option<String>,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeletedUiState {
+    #[serde(default)]
     session_ids: Vec<String>,
+    #[serde(default)]
     workspace_ids: Vec<String>,
+    #[serde(default)]
+    sessions: Vec<DeletedSessionRef>,
+    #[serde(default)]
+    workspaces: Vec<DeletedWorkspaceRef>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteSessionInput {
+    session_id: String,
+    #[serde(default)]
+    workspace_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteWorkspaceInput {
+    workspace_id: String,
+    #[serde(default)]
+    path: Option<String>,
+}
+
+fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn normalize_path(value: Option<String>) -> Option<String> {
+    normalize_optional_string(value).map(|path| normalize_expanded_path(&path))
+}
+
+impl DeletedSessionRef {
+    fn normalized(self) -> Option<Self> {
+        let session_id = self.session_id.trim().to_string();
+        if session_id.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            session_id,
+            workspace_id: normalize_optional_string(self.workspace_id),
+        })
+    }
+
+    fn matches(&self, session_id: &str, workspace_id: Option<&str>) -> bool {
+        if self.session_id != session_id.trim() {
+            return false;
+        }
+
+        match self.workspace_id.as_deref() {
+            Some(expected) => workspace_id.map(str::trim) == Some(expected),
+            None => true,
+        }
+    }
+}
+
+impl DeletedWorkspaceRef {
+    fn normalized(self) -> Option<Self> {
+        let workspace_id = self.workspace_id.trim().to_string();
+        if workspace_id.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            workspace_id,
+            path: normalize_path(self.path),
+        })
+    }
+
+    fn matches(&self, workspace_id: &str, path: Option<&str>) -> bool {
+        if self.workspace_id != workspace_id.trim() {
+            return false;
+        }
+
+        match self.path.as_deref() {
+            Some(expected) => path.map(|value| value.trim_end_matches('/')) == Some(expected),
+            None => true,
+        }
+    }
+}
+
+fn unique_session_refs(values: Vec<DeletedSessionRef>) -> Vec<DeletedSessionRef> {
+    let mut seen = HashSet::new();
+    let mut next = Vec::new();
+
+    for value in values.into_iter().filter_map(DeletedSessionRef::normalized) {
+        let key = (
+            value.session_id.clone(),
+            value.workspace_id.clone().unwrap_or_default(),
+        );
+        if seen.insert(key) {
+            next.push(value);
+        }
+    }
+
+    next.sort_by(|a, b| {
+        a.session_id
+            .cmp(&b.session_id)
+            .then_with(|| a.workspace_id.cmp(&b.workspace_id))
+    });
+    next
+}
+
+fn unique_workspace_refs(values: Vec<DeletedWorkspaceRef>) -> Vec<DeletedWorkspaceRef> {
+    let mut seen = HashSet::new();
+    let mut next = Vec::new();
+
+    for value in values.into_iter().filter_map(DeletedWorkspaceRef::normalized) {
+        let key = (
+            value.workspace_id.clone(),
+            value.path.clone().unwrap_or_default(),
+        );
+        if seen.insert(key) {
+            next.push(value);
+        }
+    }
+
+    next.sort_by(|a, b| {
+        a.workspace_id
+            .cmp(&b.workspace_id)
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    next
+}
+
+fn normalize_deleted_ui_state(mut state: DeletedUiState) -> DeletedUiState {
+    state.session_ids = state
+        .session_ids
+        .into_iter()
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    state.workspace_ids = state
+        .workspace_ids
+        .into_iter()
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    state.session_ids
+        .sort_by_key(|id| id.parse::<u64>().unwrap_or(u64::MAX));
+    state.workspace_ids.sort();
+    state.sessions = unique_session_refs(state.sessions);
+    state.workspaces = unique_workspace_refs(state.workspaces);
+    state
 }
 
 fn ui_state_file(app: &tauri::AppHandle, key: &str) -> Result<PathBuf, String> {
@@ -111,12 +278,13 @@ fn read_deleted_ui_state(app: &tauri::AppHandle) -> Result<DeletedUiState, Strin
     };
 
     serde_json::from_str::<DeletedUiState>(&content)
+        .map(normalize_deleted_ui_state)
         .map_err(|e| format!("解析已删除 UI 状态失败: {e}"))
 }
 
 fn write_deleted_ui_state(app: &tauri::AppHandle, state: &DeletedUiState) -> Result<(), String> {
-    let payload =
-        serde_json::to_string(state).map_err(|e| format!("序列化已删除 UI 状态失败: {e}"))?;
+    let payload = serde_json::to_string(&normalize_deleted_ui_state(state.clone()))
+        .map_err(|e| format!("序列化已删除 UI 状态失败: {e}"))?;
     write_ui_state(app, DELETED_UI_STATE_KEY, &payload)
 }
 
@@ -322,29 +490,49 @@ pub fn mark_deleted_items(
     app: tauri::AppHandle,
     session_ids: Vec<String>,
     workspace_ids: Vec<String>,
+    session_refs: Vec<DeleteSessionInput>,
+    workspace_refs: Vec<DeleteWorkspaceInput>,
 ) -> Result<(), String> {
     let mut state = read_deleted_ui_state(&app)?;
     let mut next_session_ids = state.session_ids.into_iter().collect::<HashSet<_>>();
     let mut next_workspace_ids = state.workspace_ids.into_iter().collect::<HashSet<_>>();
+    let mut next_session_refs = state.sessions;
+    let mut next_workspace_refs = state.workspaces;
 
     session_ids
         .into_iter()
-        .filter(|id| !id.trim().is_empty())
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty())
         .for_each(|id| {
             next_session_ids.insert(id);
         });
     workspace_ids
         .into_iter()
-        .filter(|id| !id.trim().is_empty())
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty())
         .for_each(|id| {
             next_workspace_ids.insert(id);
         });
 
+    next_session_refs.extend(session_refs.into_iter().filter_map(|item| {
+        DeletedSessionRef {
+            session_id: item.session_id,
+            workspace_id: item.workspace_id,
+        }
+        .normalized()
+    }));
+    next_workspace_refs.extend(workspace_refs.into_iter().filter_map(|item| {
+        DeletedWorkspaceRef {
+            workspace_id: item.workspace_id,
+            path: item.path,
+        }
+        .normalized()
+    }));
+
     state.session_ids = next_session_ids.into_iter().collect();
     state.workspace_ids = next_workspace_ids.into_iter().collect();
-    state.session_ids.sort_by_key(|id| id.parse::<u64>().unwrap_or(u64::MAX));
-    state.workspace_ids.sort();
-
+    state.sessions = unique_session_refs(next_session_refs);
+    state.workspaces = unique_workspace_refs(next_workspace_refs);
     write_deleted_ui_state(&app, &state)
 }
 
@@ -353,15 +541,53 @@ pub fn clear_deleted_items(
     app: tauri::AppHandle,
     session_ids: Vec<String>,
     workspace_ids: Vec<String>,
+    session_refs: Vec<DeleteSessionInput>,
+    workspace_refs: Vec<DeleteWorkspaceInput>,
 ) -> Result<(), String> {
     let mut state = read_deleted_ui_state(&app)?;
     let removed_session_ids = session_ids.into_iter().collect::<HashSet<_>>();
     let removed_workspace_ids = workspace_ids.into_iter().collect::<HashSet<_>>();
+    let removed_session_refs = session_refs
+        .into_iter()
+        .filter_map(|item| {
+            DeletedSessionRef {
+                session_id: item.session_id,
+                workspace_id: item.workspace_id,
+            }
+            .normalized()
+        })
+        .collect::<Vec<_>>();
+    let removed_workspace_refs = workspace_refs
+        .into_iter()
+        .filter_map(|item| {
+            DeletedWorkspaceRef {
+                workspace_id: item.workspace_id,
+                path: item.path,
+            }
+            .normalized()
+        })
+        .collect::<Vec<_>>();
 
-    state.session_ids.retain(|id| !removed_session_ids.contains(id));
-    state.workspace_ids.retain(|id| !removed_workspace_ids.contains(id));
+    state.session_ids
+        .retain(|id| !removed_session_ids.contains(id));
+    state.workspace_ids
+        .retain(|id| !removed_workspace_ids.contains(id));
+    state.sessions.retain(|entry| {
+        !removed_session_refs
+            .iter()
+            .any(|removed| removed.matches(&entry.session_id, entry.workspace_id.as_deref()))
+    });
+    state.workspaces.retain(|entry| {
+        !removed_workspace_refs
+            .iter()
+            .any(|removed| removed.matches(&entry.workspace_id, entry.path.as_deref()))
+    });
 
-    if state.session_ids.is_empty() && state.workspace_ids.is_empty() {
+    if state.session_ids.is_empty()
+        && state.workspace_ids.is_empty()
+        && state.sessions.is_empty()
+        && state.workspaces.is_empty()
+    {
         remove_ui_state_file(&app, DELETED_UI_STATE_KEY)
     } else {
         write_deleted_ui_state(&app, &state)
@@ -375,7 +601,8 @@ pub fn recover_workspace_sessions(
     workspace_path: String,
     existing_session_ids: Vec<String>,
 ) -> Result<Vec<RecoveredSession>, String> {
-    let repo_root = PathBuf::from(expand_path(&workspace_path));
+    let normalized_workspace_path = normalize_path(Some(workspace_path)).unwrap_or_default();
+    let repo_root = PathBuf::from(&normalized_workspace_path);
     let Some(parent) = repo_root.parent() else {
         return Ok(vec![]);
     };
@@ -385,11 +612,8 @@ pub fn recover_workspace_sessions(
         return Ok(vec![]);
     }
 
+    let deleted_state = read_deleted_ui_state(&app)?;
     let existing = existing_session_ids.into_iter().collect::<HashSet<_>>();
-    let deleted = read_deleted_ui_state(&app)?
-        .session_ids
-        .into_iter()
-        .collect::<HashSet<_>>();
     let base_branch = default_base_branch(&repo_root);
     let mut recovered = Vec::new();
 
@@ -408,7 +632,22 @@ pub fn recover_workspace_sessions(
         let Some(session_id) = numeric_session_id(dir_name) else {
             continue;
         };
-        if existing.contains(&session_id) || deleted.contains(&session_id) {
+        if existing.contains(&session_id) || deleted_state.session_ids.contains(&session_id) {
+            continue;
+        }
+        if deleted_state
+            .sessions
+            .iter()
+            .any(|entry| entry.matches(&session_id, Some(&workspace_id)))
+        {
+            continue;
+        }
+        if deleted_state.workspace_ids.contains(&workspace_id)
+            || deleted_state
+                .workspaces
+                .iter()
+                .any(|entry| entry.matches(&workspace_id, Some(&normalized_workspace_path)))
+        {
             continue;
         }
 

--- a/src-tauri/src/ui_state.rs
+++ b/src-tauri/src/ui_state.rs
@@ -44,7 +44,8 @@ pub struct RecoveredSession {
 }
 
 #[derive(Debug, Clone)]
-struct ClaudeSessionHint {
+struct RecoveryHint {
+    runner_type: String,
     provider_session_id: String,
     current_task: String,
     modified_at_ms: u64,
@@ -350,10 +351,39 @@ fn normalize_task_title(task: &str, session_id: &str) -> String {
     }
 }
 
-fn latest_claude_hint(session_id: &str) -> Option<ClaudeSessionHint> {
+fn select_newer_hint(current: &mut Option<RecoveryHint>, candidate: RecoveryHint) {
+    if current
+        .as_ref()
+        .map(|existing| existing.modified_at_ms < candidate.modified_at_ms)
+        .unwrap_or(true)
+    {
+        *current = Some(candidate);
+    }
+}
+
+fn extract_claude_first_task(json: &serde_json::Value) -> Option<String> {
+    let is_user = json.get("type").and_then(|v| v.as_str()) == Some("user");
+    let role = json
+        .get("message")
+        .and_then(|message| message.get("role"))
+        .and_then(|value| value.as_str());
+    if !is_user || role != Some("user") {
+        return None;
+    }
+
+    let content = json.get("message")?.get("content")?;
+    let text = content.as_str()?.trim();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text.to_string())
+    }
+}
+
+fn latest_claude_hint(session_id: &str) -> Option<RecoveryHint> {
     let projects_dir = home_dir()?.join(".claude").join("projects");
     let suffix = format!("session-{session_id}");
-    let mut best: Option<ClaudeSessionHint> = None;
+    let mut best: Option<RecoveryHint> = None;
 
     let Ok(project_entries) = fs::read_dir(&projects_dir) else {
         return None;
@@ -400,28 +430,9 @@ fn latest_claude_hint(session_id: &str) -> Option<ClaudeSessionHint> {
                 let Ok(json) = serde_json::from_str::<serde_json::Value>(&line) else {
                     continue;
                 };
-
-                let is_user = json.get("type").and_then(|v| v.as_str()) == Some("user");
-                let role = json
-                    .get("message")
-                    .and_then(|message| message.get("role"))
-                    .and_then(|value| value.as_str());
-                if !is_user || role != Some("user") {
-                    continue;
-                }
-
-                let Some(content) = json
-                    .get("message")
-                    .and_then(|message| message.get("content"))
-                else {
-                    continue;
-                };
-
-                if let Some(text) = content.as_str() {
-                    let trimmed = text.trim();
-                    if !trimmed.is_empty() && first_task.is_empty() {
-                        first_task = trimmed.to_string();
-                    }
+                if let Some(task) = extract_claude_first_task(&json) {
+                    first_task = task;
+                    break;
                 }
             }
 
@@ -429,23 +440,163 @@ fn latest_claude_hint(session_id: &str) -> Option<ClaudeSessionHint> {
                 continue;
             }
 
-            let modified_at_ms = modified_millis(&file_path);
-            let candidate = ClaudeSessionHint {
-                provider_session_id,
-                current_task: first_task,
-                modified_at_ms,
-            };
-
-            if best
-                .as_ref()
-                .map(|current| current.modified_at_ms < candidate.modified_at_ms)
-                .unwrap_or(true)
-            {
-                best = Some(candidate);
-            }
+            select_newer_hint(
+                &mut best,
+                RecoveryHint {
+                    runner_type: "claude-code".to_string(),
+                    provider_session_id,
+                    current_task: first_task,
+                    modified_at_ms: modified_millis(&file_path),
+                },
+            );
         }
     }
 
+    best
+}
+
+fn is_codex_wrapper_text(text: &str) -> bool {
+    matches!(
+        text.trim(),
+        value if value.starts_with("<environment_context>") || value.starts_with("<turn_aborted>")
+    )
+}
+
+fn extract_codex_first_task(json: &serde_json::Value) -> Option<String> {
+    let payload = json.get("payload")?;
+    if json.get("type").and_then(|value| value.as_str()) == Some("event_msg")
+        && payload.get("type").and_then(|value| value.as_str()) == Some("user_message")
+    {
+        return payload
+            .get("message")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|text| !text.is_empty() && !is_codex_wrapper_text(text))
+            .map(ToString::to_string);
+    }
+
+    if json.get("type").and_then(|value| value.as_str()) == Some("response_item") {
+        let message = payload.get("type").and_then(|value| value.as_str()) == Some("message");
+        let role = payload.get("role").and_then(|value| value.as_str()) == Some("user");
+        if !message || !role {
+            return None;
+        }
+        let text = payload
+            .get("content")
+            .and_then(|value| value.as_array())
+            .and_then(|items| {
+                items.iter().find_map(|item| {
+                    if item.get("type").and_then(|value| value.as_str()) != Some("input_text") {
+                        return None;
+                    }
+                    let text = item.get("text").and_then(|value| value.as_str())?.trim();
+                    if text.is_empty() || is_codex_wrapper_text(text) {
+                        return None;
+                    }
+                    Some(text.to_string())
+                })
+            });
+        if text.is_some() {
+            return text;
+        }
+    }
+
+    None
+}
+
+fn latest_codex_hint(worktree_path: &Path) -> Option<RecoveryHint> {
+    let sessions_dir = home_dir()?.join(".codex").join("sessions");
+    let target_workdir = normalize_expanded_path(&worktree_path.to_string_lossy());
+    let mut best: Option<RecoveryHint> = None;
+    let mut stack = vec![sessions_dir];
+
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+                continue;
+            }
+
+            let Ok(handle) = fs::File::open(&path) else {
+                continue;
+            };
+            let reader = BufReader::new(handle);
+            let mut provider_session_id = String::new();
+            let mut cwd = String::new();
+            let mut first_task = String::new();
+
+            for line in reader.lines().map_while(Result::ok) {
+                let Ok(json) = serde_json::from_str::<serde_json::Value>(&line) else {
+                    continue;
+                };
+
+                if provider_session_id.is_empty() {
+                    provider_session_id = json
+                        .get("payload")
+                        .and_then(|payload| payload.get("id"))
+                        .and_then(|value| value.as_str())
+                        .unwrap_or_default()
+                        .trim()
+                        .to_string();
+                }
+
+                if cwd.is_empty() {
+                    cwd = json
+                        .get("payload")
+                        .and_then(|payload| payload.get("cwd"))
+                        .and_then(|value| value.as_str())
+                        .unwrap_or_default()
+                        .trim()
+                        .to_string();
+                }
+
+                if first_task.is_empty() {
+                    if let Some(task) = extract_codex_first_task(&json) {
+                        first_task = task;
+                    }
+                }
+
+                if !provider_session_id.is_empty() && !cwd.is_empty() && !first_task.is_empty() {
+                    break;
+                }
+            }
+
+            if provider_session_id.is_empty() || cwd.is_empty() || first_task.is_empty() {
+                continue;
+            }
+
+            if normalize_expanded_path(&cwd) != target_workdir {
+                continue;
+            }
+
+            select_newer_hint(
+                &mut best,
+                RecoveryHint {
+                    runner_type: "codex".to_string(),
+                    provider_session_id,
+                    current_task: first_task,
+                    modified_at_ms: modified_millis(&path),
+                },
+            );
+        }
+    }
+
+    best
+}
+
+fn latest_recovery_hint(session_id: &str, worktree_path: &Path) -> Option<RecoveryHint> {
+    let mut best = latest_claude_hint(session_id);
+    if let Some(codex_hint) = latest_codex_hint(worktree_path) {
+        select_newer_hint(&mut best, codex_hint);
+    }
     best
 }
 
@@ -651,14 +802,14 @@ pub fn recover_workspace_sessions(
             continue;
         }
 
-        let Some(claude_hint) = latest_claude_hint(&session_id) else {
+        let Some(hint) = latest_recovery_hint(&session_id, &worktree_path) else {
             continue;
         };
 
         let branch_name =
             current_branch(&worktree_path).or_else(|| Some(format!("ci/session-{session_id}")));
         let workdir = worktree_path.to_string_lossy().to_string();
-        let current_task = claude_hint.current_task.clone();
+        let current_task = hint.current_task.clone();
 
         recovered.push(RecoveredSession {
             id: session_id.clone(),
@@ -671,7 +822,7 @@ pub fn recover_workspace_sessions(
             diff_files: vec![],
             output: vec![],
             runner: RecoveredRunnerConfig {
-                r#type: "claude-code".to_string(),
+                r#type: hint.runner_type,
                 cli_path: String::new(),
                 cli_args: String::new(),
                 api_base_url: String::new(),
@@ -680,7 +831,7 @@ pub fn recover_workspace_sessions(
             branch_name,
             base_branch: base_branch.clone(),
             worktree_path: Some(workdir),
-            provider_session_id: Some(claude_hint.provider_session_id),
+            provider_session_id: Some(hint.provider_session_id),
         });
     }
 

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -169,6 +169,10 @@ pub fn resolve_path_from_workdir(workdir: &str, path: &str) -> PathBuf {
     PathBuf::from(expand_path(workdir)).join(expanded_path)
 }
 
+pub fn normalize_expanded_path(path: &str) -> String {
+    expand_path(path).trim_end_matches('/').to_string()
+}
+
 fn provider_storage_spec(
     runner_type: &str,
 ) -> Option<(&'static str, &'static str, &'static [&'static str])> {

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -76,8 +76,18 @@ pub fn codebar_tmp_dir() -> PathBuf {
 
 #[cfg(unix)]
 pub fn hook_socket_path(file_name: &str) -> String {
+    let scoped_name = if cfg!(debug_assertions) {
+        if let Some(stripped) = file_name.strip_suffix(".sock") {
+            format!("{stripped}-dev.sock")
+        } else {
+            format!("{file_name}-dev")
+        }
+    } else {
+        file_name.to_string()
+    };
+
     codebar_runtime_dir()
-        .join(file_name)
+        .join(scoped_name)
         .to_string_lossy()
         .to_string()
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -488,7 +488,7 @@ export default function App() {
     });
   }, []);
 
-  // ── 启动时补回仍在磁盘上的丢失 session（以 worktree/Claude 历史为准）──
+  // ── 启动时补回仍在磁盘上的丢失 session（以 worktree/provider 历史为准）──
   useEffect(() => {
     if (!("__TAURI_INTERNALS__" in window)) return;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -497,18 +497,13 @@ export default function App() {
     (async () => {
       const workspaces = useWorkspaceStore.getState().workspaces;
       const knownIds = new Set(useSessionStore.getState().sessions.map((s) => s.id));
-      const recovered: ClaudeSession[] = [];
-
-      for (const workspace of workspaces) {
-        const items = await invoke<ClaudeSession[]>("recover_workspace_sessions", {
+      const recovered = await invoke<ClaudeSession[]>("recover_workspace_sessions", {
+        workspaces: workspaces.map((workspace) => ({
           workspaceId: workspace.id,
           workspacePath: workspace.path,
-          existingSessionIds: [...knownIds],
-        }).catch(() => []);
-
-        items.forEach((session) => knownIds.add(session.id));
-        recovered.push(...items);
-      }
+        })),
+        existingSessionIds: [...knownIds],
+      }).catch(() => []);
 
       if (!cancelled && recovered.length > 0) {
         useSessionStore.getState().mergeRecoveredSessions(recovered);
@@ -587,9 +582,10 @@ export default function App() {
       "provider-session-bound",
       ({ payload }) => {
         if (!payload.session_id || !payload.provider_session_id) return;
-        const existing = useSessionStore
+        const session = useSessionStore
           .getState()
-          .sessions.find((x) => x.id === payload.session_id)?.providerSessionId?.trim();
+          .sessions.find((x) => x.id === payload.session_id);
+        const existing = session?.providerSessionId?.trim();
         // 避免被“新建但空壳”的 provider 会话覆盖已有可恢复会话 ID
         if (existing && existing !== payload.provider_session_id) {
           return;
@@ -597,6 +593,14 @@ export default function App() {
         updateSession(payload.session_id, {
           providerSessionId: payload.provider_session_id,
         });
+        void invoke("save_recovery_binding", {
+          input: {
+            sessionId: payload.session_id,
+            runnerType: payload.runner_type,
+            providerSessionId: payload.provider_session_id,
+            worktreePath: session?.worktreePath ?? null,
+          },
+        }).catch(() => {});
       }
     );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { DiffViewer } from "./components/DiffViewer";
 import { StatusBar } from "./components/StatusBar";
 import { SessionDetail } from "./components/SessionDetail";
 import Settings from "./components/Settings";
-import { useSessionStore, DiffFile } from "./store/sessionStore";
+import { useSessionStore, DiffFile, type ClaudeSession } from "./store/sessionStore";
 import {
   useSettingsStore,
   isGlassTheme,
@@ -486,6 +486,38 @@ export default function App() {
         })
         .catch(() => {});
     });
+  }, []);
+
+  // ── 启动时补回仍在磁盘上的丢失 session（以 worktree/Claude 历史为准）──
+  useEffect(() => {
+    if (!("__TAURI_INTERNALS__" in window)) return;
+
+    let cancelled = false;
+
+    (async () => {
+      const workspaces = useWorkspaceStore.getState().workspaces;
+      const knownIds = new Set(useSessionStore.getState().sessions.map((s) => s.id));
+      const recovered: ClaudeSession[] = [];
+
+      for (const workspace of workspaces) {
+        const items = await invoke<ClaudeSession[]>("recover_workspace_sessions", {
+          workspaceId: workspace.id,
+          workspacePath: workspace.path,
+          existingSessionIds: [...knownIds],
+        }).catch(() => []);
+
+        items.forEach((session) => knownIds.add(session.id));
+        recovered.push(...items);
+      }
+
+      if (!cancelled && recovered.length > 0) {
+        useSessionStore.getState().mergeRecoveredSessions(recovered);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // ── 监听 Rust 侧事件 ──────────────────────────────────────

--- a/src/components/SessionDetail.tsx
+++ b/src/components/SessionDetail.tsx
@@ -317,11 +317,6 @@ function SessionPanel({ sessionId, isOpen, onClose }: PanelProps) {
     }
   }, [isOpen]);
 
-  // 首条 query 提交后才激活 PTY，避免 CLI 初始化阶段的输入竞争。
-  useEffect(() => {
-    if (querySent && worktreeReady && !ptyEverActive) setPtyEverActive(true);
-  }, [querySent, worktreeReady, ptyEverActive]);
-
   // 展开且未发送 query 时自动聚焦输入框
   useEffect(() => {
     if (isOpen && !querySent) {
@@ -337,6 +332,13 @@ function SessionPanel({ sessionId, isOpen, onClose }: PanelProps) {
     ? (ptyEverActive ? launchResumeSessionId : boundResumeSessionId)
     : "";
   const isResumeLaunch = resumeSessionId.length > 0;
+
+  // 首条 query 提交后激活 PTY；resume 场景不依赖 worktreeReady，避免白屏。
+  useEffect(() => {
+    if (querySent && (worktreeReady || isResumeLaunch) && !ptyEverActive) {
+      setPtyEverActive(true);
+    }
+  }, [querySent, worktreeReady, isResumeLaunch, ptyEverActive]);
 
   useEffect(() => {
     if (!supportsPromptLaunch) {

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -477,6 +477,15 @@ export function SessionList() {
     setExpandedSession(id);
 
     if ("__TAURI_INTERNALS__" in window) {
+      await invoke("clear_deleted_items", {
+        sessionIds: [id],
+        workspaceIds: [],
+      }).catch((e) => {
+        console.warn("[ui-state] clear deleted session failed:", e);
+      });
+    }
+
+    if ("__TAURI_INTERNALS__" in window) {
       try {
         const result = await invoke<{
           worktree_path: string;
@@ -502,7 +511,16 @@ export function SessionList() {
     markWorktreeReady(id);
   };
 
-  const handleRemoveSession = (session: ClaudeSession) => {
+  const handleRemoveSession = async (session: ClaudeSession) => {
+    if ("__TAURI_INTERNALS__" in window) {
+      await invoke("mark_deleted_items", {
+        sessionIds: [session.id],
+        workspaceIds: [],
+      }).catch((e) => {
+        console.warn("[ui-state] mark deleted session failed:", e);
+      });
+    }
+
     removeSession(session.id);
 
     const workspacePath = activeWorkspace?.path;

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -516,7 +516,7 @@ export function SessionList() {
   const handleRemoveSession = async (session: ClaudeSession) => {
     if ("__TAURI_INTERNALS__" in window) {
       await invoke("mark_deleted_items", {
-        sessionIds: [],
+        sessionIds: [session.id],
         workspaceIds: [],
         sessionRefs: [{ sessionId: session.id, workspaceId: session.workspaceId }],
         workspaceRefs: [],

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -480,6 +480,8 @@ export function SessionList() {
       await invoke("clear_deleted_items", {
         sessionIds: [id],
         workspaceIds: [],
+        sessionRefs: [{ sessionId: id, workspaceId: activeWorkspace.id }],
+        workspaceRefs: [],
       }).catch((e) => {
         console.warn("[ui-state] clear deleted session failed:", e);
       });
@@ -514,8 +516,10 @@ export function SessionList() {
   const handleRemoveSession = async (session: ClaudeSession) => {
     if ("__TAURI_INTERNALS__" in window) {
       await invoke("mark_deleted_items", {
-        sessionIds: [session.id],
+        sessionIds: [],
         workspaceIds: [],
+        sessionRefs: [{ sessionId: session.id, workspaceId: session.workspaceId }],
+        workspaceRefs: [],
       }).catch((e) => {
         console.warn("[ui-state] mark deleted session failed:", e);
       });

--- a/src/components/WorkspaceStack.tsx
+++ b/src/components/WorkspaceStack.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useMemo, useState, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -222,16 +222,20 @@ function WorkspaceCardExpanded({
   const isGlass = useSettingsStore((s) => isGlassTheme(s.settings.theme));
   const textShadow = isGlass ? "var(--ci-glass-text-shadow)" : "none";
   const color = getWorkspaceColor(ws.color);
-  const { sessionCount, waitingCount, runningCount } = useSessionStore((s) => s.sessions.reduce(
-    (counts, sess) => {
-      if (sess.workspaceId !== ws.id) return counts;
-      counts.sessionCount += 1;
-      if (sess.status === "waiting") counts.waitingCount += 1;
-      if (sess.status === "running") counts.runningCount += 1;
-      return counts;
-    },
-    { sessionCount: 0, waitingCount: 0, runningCount: 0 }
-  ));
+  const sessions = useSessionStore((s) => (Array.isArray(s.sessions) ? s.sessions : []));
+  const { sessionCount, waitingCount, runningCount } = useMemo(() => {
+    return sessions.reduce(
+      (counts, sess) => {
+        if (!sess || typeof sess !== "object") return counts;
+        if (sess.workspaceId !== ws.id) return counts;
+        counts.sessionCount += 1;
+        if (sess.status === "waiting") counts.waitingCount += 1;
+        if (sess.status === "running") counts.runningCount += 1;
+        return counts;
+      },
+      { sessionCount: 0, waitingCount: 0, runningCount: 0 }
+    );
+  }, [sessions, ws.id]);
 
   return (
     <div
@@ -489,6 +493,40 @@ export function WorkspaceStack() {
   const suppressHoverExpandRef = useRef(false);
   const lastPointerRef = useRef<{ x: number; y: number } | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const collapsedHeight = CARD_H + Math.min(sorted.length - 1, 3) * CARD_PEEK;
+
+  useEffect(() => {
+    const handlePointerMove = (event: PointerEvent) => {
+      lastPointerRef.current = { x: event.clientX, y: event.clientY };
+      if (!suppressHoverExpandRef.current || expanded) return;
+      const root = rootRef.current;
+      if (!root) return;
+      const rect = root.getBoundingClientRect();
+      const inside =
+        event.clientX >= rect.left &&
+        event.clientX <= rect.right &&
+        event.clientY >= rect.top &&
+        event.clientY <= rect.bottom;
+      if (!inside) {
+        suppressHoverExpandRef.current = false;
+      }
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (!expanded || !target) return;
+      if (rootRef.current?.contains(target)) return;
+      suppressHoverExpandRef.current = false;
+      setExpanded(false);
+    };
+
+    document.addEventListener("pointermove", handlePointerMove, true);
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => {
+      document.removeEventListener("pointermove", handlePointerMove, true);
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [expanded]);
 
   // 没有 workspace 时只渲染添加表单
   if (workspaces.length === 0) {
@@ -575,41 +613,6 @@ export function WorkspaceStack() {
       });
     });
   };
-  const collapsedHeight = CARD_H + Math.min(sorted.length - 1, 3) * CARD_PEEK;
-
-  useEffect(() => {
-    const handlePointerMove = (event: PointerEvent) => {
-      lastPointerRef.current = { x: event.clientX, y: event.clientY };
-      if (!suppressHoverExpandRef.current || expanded) return;
-      const root = rootRef.current;
-      if (!root) return;
-      const rect = root.getBoundingClientRect();
-      const inside =
-        event.clientX >= rect.left &&
-        event.clientX <= rect.right &&
-        event.clientY >= rect.top &&
-        event.clientY <= rect.bottom;
-      if (!inside) {
-        suppressHoverExpandRef.current = false;
-      }
-    };
-
-    const handlePointerDown = (event: PointerEvent) => {
-      const target = event.target as Node | null;
-      if (!expanded || !target) return;
-      if (rootRef.current?.contains(target)) return;
-      suppressHoverExpandRef.current = false;
-      setExpanded(false);
-    };
-
-    document.addEventListener("pointermove", handlePointerMove, true);
-    document.addEventListener("pointerdown", handlePointerDown);
-    return () => {
-      document.removeEventListener("pointermove", handlePointerMove, true);
-      document.removeEventListener("pointerdown", handlePointerDown);
-    };
-  }, [expanded]);
-
   return (
     <div ref={rootRef} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
       {/* ── 标题栏 ── */}

--- a/src/components/WorkspaceStack.tsx
+++ b/src/components/WorkspaceStack.tsx
@@ -42,10 +42,20 @@ function NewWorkspaceForm({ onDone }: { onDone: () => void }) {
     }
   };
 
-  const handleCreate = () => {
+  const handleCreate = async () => {
     const trimmed = path.trim();
     if (!trimmed) { setError("请选择工作目录"); return; }
-    addWorkspace(trimmed, name.trim() || undefined, color);
+    const workspaceId = addWorkspace(trimmed, name.trim() || undefined, color);
+    if ("__TAURI_INTERNALS__" in window) {
+      await invoke("clear_deleted_items", {
+        sessionIds: [],
+        workspaceIds: [],
+        sessionRefs: [],
+        workspaceRefs: [{ workspaceId, path: trimmed }],
+      }).catch((e) => {
+        console.warn("[ui-state] clear deleted workspace failed:", e);
+      });
+    }
     invoke("trust_workspace", { path: trimmed }).catch(() => {});
     onDone();
   };
@@ -188,15 +198,16 @@ function WorkspaceCardExpanded({
   const isGlass = useSettingsStore((s) => isGlassTheme(s.settings.theme));
   const textShadow = isGlass ? "var(--ci-glass-text-shadow)" : "none";
   const color = getWorkspaceColor(ws.color);
-  const sessionCount = useSessionStore((s) =>
-    s.sessions.filter((sess) => sess.workspaceId === ws.id).length
-  );
-  const waitingCount = useSessionStore((s) =>
-    s.sessions.filter((sess) => sess.workspaceId === ws.id && sess.status === "waiting").length
-  );
-  const runningCount = useSessionStore((s) =>
-    s.sessions.filter((sess) => sess.workspaceId === ws.id && sess.status === "running").length
-  );
+  const { sessionCount, waitingCount, runningCount } = useSessionStore((s) => s.sessions.reduce(
+    (counts, sess) => {
+      if (sess.workspaceId !== ws.id) return counts;
+      counts.sessionCount += 1;
+      if (sess.status === "waiting") counts.waitingCount += 1;
+      if (sess.status === "running") counts.runningCount += 1;
+      return counts;
+    },
+    { sessionCount: 0, waitingCount: 0, runningCount: 0 }
+  ));
 
   return (
     <motion.div
@@ -507,8 +518,13 @@ export function WorkspaceStack() {
 
     if ("__TAURI_INTERNALS__" in window) {
       await invoke("mark_deleted_items", {
-        sessionIds: sessionsToRemove.map((session) => session.id),
-        workspaceIds: [id],
+        sessionIds: [],
+        workspaceIds: [],
+        sessionRefs: sessionsToRemove.map((session) => ({
+          sessionId: session.id,
+          workspaceId: session.workspaceId,
+        })),
+        workspaceRefs: workspace ? [{ workspaceId: id, path: workspace.path }] : [{ workspaceId: id }],
       }).catch((e) => {
         console.warn("[ui-state] mark deleted workspace failed:", e);
       });

--- a/src/components/WorkspaceStack.tsx
+++ b/src/components/WorkspaceStack.tsx
@@ -9,7 +9,7 @@ import {
   type Workspace,
   type WorkspaceColorId,
 } from "../store/workspaceStore";
-import { useSessionStore } from "../store/sessionStore";
+import { useSessionStore, type ClaudeSession } from "../store/sessionStore";
 import { useSettingsStore, isGlassTheme } from "../store/settingsStore";
 
 // ── 常量 ─────────────────────────────────────────────────────
@@ -498,9 +498,40 @@ export function WorkspaceStack() {
     );
   }
 
-  const handleRemove = (id: string) => {
+  const handleRemove = async (id: string) => {
+    const sessionsToRemove = useSessionStore
+      .getState()
+      .sessions
+      .filter((session) => session.workspaceId === id);
+    const workspace = workspaces.find((item) => item.id === id);
+
+    if ("__TAURI_INTERNALS__" in window) {
+      await invoke("mark_deleted_items", {
+        sessionIds: sessionsToRemove.map((session) => session.id),
+        workspaceIds: [id],
+      }).catch((e) => {
+        console.warn("[ui-state] mark deleted workspace failed:", e);
+      });
+    }
+
     removeSessionsByWorkspace(id);
     removeWorkspace(id);
+
+    if (!("__TAURI_INTERNALS__" in window) || !workspace?.path) {
+      return;
+    }
+
+    sessionsToRemove.forEach((session: ClaudeSession) => {
+      if (!session.worktreePath || !session.branchName) return;
+
+      invoke("teardown_session_worktree", {
+        workdir: workspace.path,
+        worktreePath: session.worktreePath,
+        branch: session.branchName,
+      }).catch((e) => {
+        console.warn("[worktree] workspace teardown failed:", e);
+      });
+    });
   };
 
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import { bootstrapPersistState } from "./store/persistStorage";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+async function main() {
+  await bootstrapPersistState();
+
+  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}
+
+void main();

--- a/src/store/persistStorage.ts
+++ b/src/store/persistStorage.ts
@@ -61,6 +61,8 @@ interface PersistedWorkspacesState {
   version?: number;
 }
 
+let cachedHomeDir = "";
+
 function isTauriRuntime(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
@@ -99,8 +101,20 @@ function uniqueStrings(values: string[]): string[] {
   return next;
 }
 
+function expandHomePath(path: string): string {
+  if (!path.startsWith("~")) return path;
+  if (!cachedHomeDir) return path;
+  if (path === "~") return cachedHomeDir;
+  if (path.startsWith("~/") || path.startsWith("~\\")) {
+    return `${cachedHomeDir}/${path.slice(2)}`;
+  }
+  return path;
+}
+
 function normalizePath(path: string | null | undefined): string {
-  return (path ?? "").trim().replace(/\/+$/, "");
+  const trimmed = (path ?? "").trim();
+  if (!trimmed) return "";
+  return expandHomePath(trimmed).replace(/[\\/]+$/, "");
 }
 
 function normalizeDeletedSessionRef(ref: DeletedSessionRef | null | undefined): DeletedSessionRef | null {
@@ -318,6 +332,15 @@ function mergePersistedValue(
 
 export async function bootstrapPersistState(): Promise<void> {
   if (typeof window === "undefined" || !("localStorage" in window)) return;
+
+  if (isTauriRuntime()) {
+    try {
+      const { homeDir } = await import("@tauri-apps/api/path");
+      cachedHomeDir = (await homeDir()).replace(/[\\/]+$/, "");
+    } catch {
+      cachedHomeDir = "";
+    }
+  }
 
   const fromFile = await invokeSafe<Record<string, string | null>>("load_ui_states", {
     keys: [...PERSIST_KEYS],

--- a/src/store/persistStorage.ts
+++ b/src/store/persistStorage.ts
@@ -8,9 +8,28 @@ const PERSIST_KEYS = [
 
 type PersistKey = typeof PERSIST_KEYS[number];
 
+interface DeletedSessionRef {
+  sessionId: string;
+  workspaceId?: string | null;
+}
+
+interface DeletedWorkspaceRef {
+  workspaceId: string;
+  path?: string | null;
+}
+
 interface DeletedUiState {
   sessionIds?: string[];
   workspaceIds?: string[];
+  sessions?: DeletedSessionRef[];
+  workspaces?: DeletedWorkspaceRef[];
+}
+
+interface DeletedMatchers {
+  legacySessionIds: Set<string>;
+  legacyWorkspaceIds: Set<string>;
+  sessionRefs: DeletedSessionRef[];
+  workspaceRefs: DeletedWorkspaceRef[];
 }
 
 interface PersistedSessionLike {
@@ -30,6 +49,7 @@ interface PersistedSessionsState {
 
 interface PersistedWorkspaceLike {
   id: string;
+  path?: string;
   order?: number;
 }
 
@@ -79,10 +99,96 @@ function uniqueStrings(values: string[]): string[] {
   return next;
 }
 
+function normalizePath(path: string | null | undefined): string {
+  return (path ?? "").trim().replace(/\/+$/, "");
+}
+
+function normalizeDeletedSessionRef(ref: DeletedSessionRef | null | undefined): DeletedSessionRef | null {
+  const sessionId = ref?.sessionId?.trim() ?? "";
+  if (!sessionId) return null;
+
+  const workspaceId = ref?.workspaceId?.trim() ?? "";
+  return workspaceId ? { sessionId, workspaceId } : { sessionId };
+}
+
+function normalizeDeletedWorkspaceRef(ref: DeletedWorkspaceRef | null | undefined): DeletedWorkspaceRef | null {
+  const workspaceId = ref?.workspaceId?.trim() ?? "";
+  if (!workspaceId) return null;
+
+  const path = normalizePath(ref?.path);
+  return path ? { workspaceId, path } : { workspaceId };
+}
+
+function uniqueByKey<T>(values: T[], keyOf: (value: T) => string): T[] {
+  const seen = new Set<string>();
+  const next: T[] = [];
+
+  values.forEach((value) => {
+    const key = keyOf(value);
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    next.push(value);
+  });
+
+  return next;
+}
+
+function buildDeletedMatchers(state: DeletedUiState): DeletedMatchers {
+  const legacySessionIds = new Set(uniqueStrings((state.sessionIds ?? []).map((id) => id.trim())));
+  const legacyWorkspaceIds = new Set(uniqueStrings((state.workspaceIds ?? []).map((id) => id.trim())));
+  const sessionRefs = uniqueByKey(
+    (state.sessions ?? [])
+      .map((ref) => normalizeDeletedSessionRef(ref))
+      .filter((ref): ref is DeletedSessionRef => !!ref),
+    (ref) => `${ref.sessionId}::${ref.workspaceId ?? ""}`
+  );
+  const workspaceRefs = uniqueByKey(
+    (state.workspaces ?? [])
+      .map((ref) => normalizeDeletedWorkspaceRef(ref))
+      .filter((ref): ref is DeletedWorkspaceRef => !!ref),
+    (ref) => `${ref.workspaceId}::${normalizePath(ref.path)}`
+  );
+
+  return {
+    legacySessionIds,
+    legacyWorkspaceIds,
+    sessionRefs,
+    workspaceRefs,
+  };
+}
+
+function matchesDeletedSession(
+  deleted: DeletedMatchers,
+  session: PersistedSessionLike
+): boolean {
+  if (!session?.id) return false;
+  if (deleted.legacySessionIds.has(session.id)) return true;
+  if (deleted.legacyWorkspaceIds.has(session.workspaceId)) return true;
+
+  return deleted.sessionRefs.some((ref) => {
+    if (ref.sessionId !== session.id) return false;
+    return !ref.workspaceId || ref.workspaceId === session.workspaceId;
+  });
+}
+
+function matchesDeletedWorkspace(
+  deleted: DeletedMatchers,
+  workspace: PersistedWorkspaceLike
+): boolean {
+  if (!workspace?.id) return false;
+  if (deleted.legacyWorkspaceIds.has(workspace.id)) return true;
+
+  return deleted.workspaceRefs.some((ref) => {
+    if (ref.workspaceId !== workspace.id) return false;
+    const deletedPath = normalizePath(ref.path);
+    return !deletedPath || deletedPath === normalizePath(workspace.path);
+  });
+}
+
 function mergeSessionValue(
   fileValue: string | null,
   localValue: string | null,
-  deleted: { sessionIds: Set<string>; workspaceIds: Set<string> }
+  deletedState: DeletedUiState
 ): string | null {
   const fileState = parseJson<PersistedSessionsState>(fileValue);
   const localState = parseJson<PersistedSessionsState>(localValue);
@@ -90,10 +196,9 @@ function mergeSessionValue(
     return localValue ?? fileValue ?? null;
   }
 
+  const deleted = buildDeletedMatchers(deletedState);
   const shouldKeepSession = (session: PersistedSessionLike) =>
-    !!session?.id
-    && !deleted.sessionIds.has(session.id)
-    && !deleted.workspaceIds.has(session.workspaceId);
+    !!session?.id && !matchesDeletedSession(deleted, session);
 
   const localSessions = (localState?.state?.sessions ?? []).filter(shouldKeepSession);
   const fileSessions = (fileState?.state?.sessions ?? []).filter(shouldKeepSession);
@@ -148,7 +253,7 @@ function mergeSessionValue(
 function mergeWorkspaceValue(
   fileValue: string | null,
   localValue: string | null,
-  deletedWorkspaceIds: Set<string>
+  deletedState: DeletedUiState
 ): string | null {
   const fileState = parseJson<PersistedWorkspacesState>(fileValue);
   const localState = parseJson<PersistedWorkspacesState>(localValue);
@@ -156,8 +261,9 @@ function mergeWorkspaceValue(
     return localValue ?? fileValue ?? null;
   }
 
+  const deleted = buildDeletedMatchers(deletedState);
   const shouldKeepWorkspace = (workspace: PersistedWorkspaceLike) =>
-    !!workspace?.id && !deletedWorkspaceIds.has(workspace.id);
+    !!workspace?.id && !matchesDeletedWorkspace(deleted, workspace);
 
   const sortByOrder = <T extends { order?: number }>(items: T[]) =>
     [...items].sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER));
@@ -198,17 +304,11 @@ function mergePersistedValue(
   localValue: string | null,
   deletedState: DeletedUiState
 ): string | null {
-  const deletedSessionIds = new Set(deletedState.sessionIds ?? []);
-  const deletedWorkspaceIds = new Set(deletedState.workspaceIds ?? []);
-
   switch (key) {
     case "code-bar-sessions":
-      return mergeSessionValue(fileValue, localValue, {
-        sessionIds: deletedSessionIds,
-        workspaceIds: deletedWorkspaceIds,
-      });
+      return mergeSessionValue(fileValue, localValue, deletedState);
     case "code-bar-workspaces":
-      return mergeWorkspaceValue(fileValue, localValue, deletedWorkspaceIds);
+      return mergeWorkspaceValue(fileValue, localValue, deletedState);
     case "code-bar-settings":
       return localValue ?? fileValue ?? null;
     default:

--- a/src/store/persistStorage.ts
+++ b/src/store/persistStorage.ts
@@ -1,0 +1,267 @@
+import type { StateStorage } from "zustand/middleware";
+
+const PERSIST_KEYS = [
+  "code-bar-sessions",
+  "code-bar-workspaces",
+  "code-bar-settings",
+] as const;
+
+type PersistKey = typeof PERSIST_KEYS[number];
+
+interface DeletedUiState {
+  sessionIds?: string[];
+  workspaceIds?: string[];
+}
+
+interface PersistedSessionLike {
+  id: string;
+  workspaceId: string;
+  createdAt?: number;
+}
+
+interface PersistedSessionsState {
+  state?: {
+    sessions?: PersistedSessionLike[];
+    activeSessionId?: string | null;
+    sessionOrderByWorkspace?: Record<string, string[]>;
+  };
+  version?: number;
+}
+
+interface PersistedWorkspaceLike {
+  id: string;
+  order?: number;
+}
+
+interface PersistedWorkspacesState {
+  state?: {
+    workspaces?: PersistedWorkspaceLike[];
+    activeWorkspaceId?: string | null;
+  };
+  version?: number;
+}
+
+function isTauriRuntime(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+async function invokeSafe<T>(command: string, args: Record<string, unknown>): Promise<T | null> {
+  if (!isTauriRuntime()) return null;
+
+  try {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<T>(command, args);
+  } catch {
+    return null;
+  }
+}
+
+function parseJson<T>(value: string | null): T | null {
+  if (!value) return null;
+
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return null;
+  }
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const next: string[] = [];
+
+  values.forEach((value) => {
+    if (!value || seen.has(value)) return;
+    seen.add(value);
+    next.push(value);
+  });
+
+  return next;
+}
+
+function mergeSessionValue(
+  fileValue: string | null,
+  localValue: string | null,
+  deleted: { sessionIds: Set<string>; workspaceIds: Set<string> }
+): string | null {
+  const fileState = parseJson<PersistedSessionsState>(fileValue);
+  const localState = parseJson<PersistedSessionsState>(localValue);
+  if (!fileState && !localState) {
+    return localValue ?? fileValue ?? null;
+  }
+
+  const shouldKeepSession = (session: PersistedSessionLike) =>
+    !!session?.id
+    && !deleted.sessionIds.has(session.id)
+    && !deleted.workspaceIds.has(session.workspaceId);
+
+  const localSessions = (localState?.state?.sessions ?? []).filter(shouldKeepSession);
+  const fileSessions = (fileState?.state?.sessions ?? []).filter(shouldKeepSession);
+  const mergedSessions = [...localSessions];
+  const existingIds = new Set(localSessions.map((session) => session.id));
+
+  fileSessions.forEach((session) => {
+    if (existingIds.has(session.id)) return;
+    existingIds.add(session.id);
+    mergedSessions.push(session);
+  });
+
+  const validIds = new Set(mergedSessions.map((session) => session.id));
+  const workspaceIds = uniqueStrings([
+    ...mergedSessions.map((session) => session.workspaceId),
+    ...Object.keys(localState?.state?.sessionOrderByWorkspace ?? {}),
+    ...Object.keys(fileState?.state?.sessionOrderByWorkspace ?? {}),
+  ]);
+
+  const sessionOrderByWorkspace = workspaceIds.reduce<Record<string, string[]>>((acc, workspaceId) => {
+    const preferred = (localState?.state?.sessionOrderByWorkspace?.[workspaceId] ?? [])
+      .filter((id) => validIds.has(id));
+    const fallback = (fileState?.state?.sessionOrderByWorkspace?.[workspaceId] ?? [])
+      .filter((id) => validIds.has(id));
+    const owned = mergedSessions
+      .filter((session) => session.workspaceId === workspaceId)
+      .sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0))
+      .map((session) => session.id);
+    const mergedOrder = uniqueStrings([...preferred, ...fallback, ...owned]);
+
+    if (mergedOrder.length > 0) {
+      acc[workspaceId] = mergedOrder;
+    }
+    return acc;
+  }, {});
+
+  const activeSessionId = [localState?.state?.activeSessionId, fileState?.state?.activeSessionId]
+    .find((id): id is string => !!id && validIds.has(id))
+    ?? mergedSessions[0]?.id
+    ?? null;
+
+  return JSON.stringify({
+    state: {
+      sessions: mergedSessions,
+      activeSessionId,
+      sessionOrderByWorkspace,
+    },
+    version: localState?.version ?? fileState?.version ?? 0,
+  });
+}
+
+function mergeWorkspaceValue(
+  fileValue: string | null,
+  localValue: string | null,
+  deletedWorkspaceIds: Set<string>
+): string | null {
+  const fileState = parseJson<PersistedWorkspacesState>(fileValue);
+  const localState = parseJson<PersistedWorkspacesState>(localValue);
+  if (!fileState && !localState) {
+    return localValue ?? fileValue ?? null;
+  }
+
+  const shouldKeepWorkspace = (workspace: PersistedWorkspaceLike) =>
+    !!workspace?.id && !deletedWorkspaceIds.has(workspace.id);
+
+  const sortByOrder = <T extends { order?: number }>(items: T[]) =>
+    [...items].sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER));
+
+  const localWorkspaces = sortByOrder((localState?.state?.workspaces ?? []).filter(shouldKeepWorkspace));
+  const fileWorkspaces = sortByOrder((fileState?.state?.workspaces ?? []).filter(shouldKeepWorkspace));
+  const mergedWorkspaces = [...localWorkspaces];
+  const existingIds = new Set(localWorkspaces.map((workspace) => workspace.id));
+
+  fileWorkspaces.forEach((workspace) => {
+    if (existingIds.has(workspace.id)) return;
+    existingIds.add(workspace.id);
+    mergedWorkspaces.push(workspace);
+  });
+
+  const normalizedWorkspaces = mergedWorkspaces.map((workspace, index) => ({
+    ...workspace,
+    order: index,
+  }));
+  const validIds = new Set(normalizedWorkspaces.map((workspace) => workspace.id));
+  const activeWorkspaceId = [localState?.state?.activeWorkspaceId, fileState?.state?.activeWorkspaceId]
+    .find((id): id is string => !!id && validIds.has(id))
+    ?? normalizedWorkspaces[0]?.id
+    ?? null;
+
+  return JSON.stringify({
+    state: {
+      workspaces: normalizedWorkspaces,
+      activeWorkspaceId,
+    },
+    version: localState?.version ?? fileState?.version ?? 0,
+  });
+}
+
+function mergePersistedValue(
+  key: PersistKey,
+  fileValue: string | null,
+  localValue: string | null,
+  deletedState: DeletedUiState
+): string | null {
+  const deletedSessionIds = new Set(deletedState.sessionIds ?? []);
+  const deletedWorkspaceIds = new Set(deletedState.workspaceIds ?? []);
+
+  switch (key) {
+    case "code-bar-sessions":
+      return mergeSessionValue(fileValue, localValue, {
+        sessionIds: deletedSessionIds,
+        workspaceIds: deletedWorkspaceIds,
+      });
+    case "code-bar-workspaces":
+      return mergeWorkspaceValue(fileValue, localValue, deletedWorkspaceIds);
+    case "code-bar-settings":
+      return localValue ?? fileValue ?? null;
+    default:
+      return localValue ?? fileValue ?? null;
+  }
+}
+
+export async function bootstrapPersistState(): Promise<void> {
+  if (typeof window === "undefined" || !("localStorage" in window)) return;
+
+  const fromFile = await invokeSafe<Record<string, string | null>>("load_ui_states", {
+    keys: [...PERSIST_KEYS],
+  });
+  const deletedState = (await invokeSafe<DeletedUiState>("load_deleted_ui_state", {})) ?? {};
+
+  for (const key of PERSIST_KEYS) {
+    const fileValue = fromFile?.[key] ?? null;
+    const localValue = window.localStorage.getItem(key);
+    const mergedValue = mergePersistedValue(key, fileValue, localValue, deletedState);
+
+    if (mergedValue !== null) {
+      if (window.localStorage.getItem(key) !== mergedValue) {
+        window.localStorage.setItem(key, mergedValue);
+      }
+      if (fileValue !== mergedValue) {
+        void invokeSafe("save_ui_state", { key, value: mergedValue });
+      }
+      continue;
+    }
+
+    if (localValue !== null) {
+      void invokeSafe("save_ui_state", { key, value: localValue });
+    }
+  }
+}
+
+export const mirroredPersistStorage: StateStorage = {
+  getItem: (name) => {
+    if (typeof window === "undefined" || !("localStorage" in window)) return null;
+    return window.localStorage.getItem(name);
+  },
+
+  setItem: (name, value) => {
+    if (typeof window === "undefined" || !("localStorage" in window)) return;
+
+    window.localStorage.setItem(name, value);
+    void invokeSafe("save_ui_state", { key: name, value });
+  },
+
+  removeItem: (name) => {
+    if (typeof window === "undefined" || !("localStorage" in window)) return;
+
+    window.localStorage.removeItem(name);
+    void invokeSafe("remove_ui_state", { key: name });
+  },
+};

--- a/src/store/sessionStore.ts
+++ b/src/store/sessionStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
 import type { RunnerConfig } from "./settingsStore";
+import { mirroredPersistStorage } from "./persistStorage";
 
 // ── 类型定义 ────────────────────────────────────────────────
 
@@ -66,6 +67,7 @@ interface SessionStore {
   setExpandedSession: (id: string | null) => void;
   removeSessionsByWorkspace: (workspaceId: string) => void;
   markWorktreeReady: (id: string) => void;
+  mergeRecoveredSessions: (sessions: ClaudeSession[]) => void;
   reorderWorkspaceSessions: (workspaceId: string, orderedSessionIds: string[]) => void;
   reorderWorkspaceSessionsByVisibleMove: (workspaceId: string, activeId: string, overId: string) => void;
 }
@@ -252,6 +254,51 @@ export const useSessionStore = create<SessionStore>()(
           return { worktreeReadyIds };
         }),
 
+      mergeRecoveredSessions: (recoveredSessions) =>
+        set((state) => {
+          if (recoveredSessions.length === 0) return {};
+
+          const existingIds = new Set(state.sessions.map((s) => s.id));
+          const sessions = [...state.sessions];
+          const worktreeReadyIds = new Set(state.worktreeReadyIds);
+          const sessionOrderByWorkspace = { ...state.sessionOrderByWorkspace };
+          let added = false;
+
+          for (const recovered of recoveredSessions) {
+            if (existingIds.has(recovered.id)) continue;
+
+            sessions.push({
+              ...recovered,
+              runner: { ...recovered.runner },
+              diffFiles: [...recovered.diffFiles],
+              output: [...recovered.output],
+            });
+            existingIds.add(recovered.id);
+            added = true;
+
+            if (recovered.worktreePath) {
+              worktreeReadyIds.add(recovered.id);
+            }
+
+            const workspaceId = recovered.workspaceId;
+            const nextOrder = [...(sessionOrderByWorkspace[workspaceId] ?? []), recovered.id];
+            sessionOrderByWorkspace[workspaceId] = buildWorkspaceManualOrder(
+              sessions,
+              workspaceId,
+              nextOrder
+            );
+          }
+
+          if (!added) return {};
+
+          return {
+            sessions,
+            worktreeReadyIds,
+            sessionOrderByWorkspace,
+            activeSessionId: state.activeSessionId ?? recoveredSessions[0]?.id ?? null,
+          };
+        }),
+
       reorderWorkspaceSessions: (workspaceId, orderedSessionIds) =>
         set((state) => {
           const manualOrder = buildWorkspaceManualOrder(
@@ -313,6 +360,7 @@ export const useSessionStore = create<SessionStore>()(
     }),
     {
       name: "code-bar-sessions",
+      storage: createJSONStorage(() => mirroredPersistStorage),
       // expandedSessionId 和 worktreeReadyIds 不持久化
       partialize: (state) => ({
         sessions: state.sessions.map((s) => ({

--- a/src/store/sessionStore.ts
+++ b/src/store/sessionStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
-import type { RunnerConfig } from "./settingsStore";
 import { mirroredPersistStorage } from "./persistStorage";
+import { useSettingsStore, type RunnerConfig } from "./settingsStore";
 
 // ── 类型定义 ────────────────────────────────────────────────
 
@@ -124,6 +124,21 @@ export function orderWorkspaceSessions(
   });
 }
 
+function resolveRunnerField(current: string | undefined, fallback: string | undefined): string | undefined {
+  return current && current.trim() ? current : fallback;
+}
+
+function hydrateRunnerConfig(runner: RunnerConfig): RunnerConfig {
+  const resolved = useSettingsStore.getState().getRunnerConfigForType(runner.type);
+  return {
+    type: runner.type,
+    cliPath: resolveRunnerField(runner.cliPath, resolved.cliPath),
+    cliArgs: resolveRunnerField(runner.cliArgs, resolved.cliArgs),
+    apiBaseUrl: resolveRunnerField(runner.apiBaseUrl, resolved.apiBaseUrl),
+    apiKeyOverride: resolveRunnerField(runner.apiKeyOverride, resolved.apiKeyOverride),
+  };
+}
+
 function makeSession(
   overrides: Partial<Omit<ClaudeSession, "runner">> & { workspaceId: string; workdir: string; runner: RunnerConfig }
 ): ClaudeSession {
@@ -137,6 +152,7 @@ function makeSession(
     diffFiles: [],
     output: [],
     ...overrides,
+    runner: hydrateRunnerConfig(overrides.runner),
   };
 }
 
@@ -269,7 +285,7 @@ export const useSessionStore = create<SessionStore>()(
 
             sessions.push({
               ...recovered,
-              runner: { ...recovered.runner },
+              runner: hydrateRunnerConfig(recovered.runner),
               diffFiles: [...recovered.diffFiles],
               output: [...recovered.output],
             });

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { mirroredPersistStorage } from "./persistStorage";
 
 export type RunnerType =
   | "claude-code"
@@ -172,6 +173,7 @@ export const useSettingsStore = create<SettingsStore>()(
     }),
     {
       name: "code-bar-settings",
+      storage: createJSONStorage(() => mirroredPersistStorage),
       partialize: (s) => ({
         settings: {
           ...s.settings,

--- a/src/store/workspaceStore.ts
+++ b/src/store/workspaceStore.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { mirroredPersistStorage } from "./persistStorage";
 
 export const WORKSPACE_COLORS = [
   { id: "blue",   hex: "#3b82f6", label: "蓝" },
@@ -105,7 +106,10 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
           ),
         })),
     }),
-    { name: "code-bar-workspaces" }
+    {
+      name: "code-bar-workspaces",
+      storage: createJSONStorage(() => mirroredPersistStorage),
+    }
   )
 );
 


### PR DESCRIPTION
  ### Situation                                                                                                         
  在 release 环境下，session/workspace 的恢复依赖 WebView `localStorage` 和镜像文件。实际使用中出现了：
  - 删除旧 session 后，新建并使用新的 session                                                                           
  - 退出再打开应用时，新 session 丢失                                                                                   
  - 已删除的旧 session 又重新出现                                                                                       
                                                                                                                        
  根因是删除 tombstone 只按裸 `sessionId` / `workspaceId` 记录，启动时 file-only                                        
  项又可能被重新补回，导致删除语义不稳定。                                                                              
                                                                                                                        
  ### Task                                                  
  本次改动的目标是：
  - 保证已删除的 session/workspace 在重启后不会因旧镜像或残留 worktree 被恢复回来
  - 保留 local-first 的启动恢复语义                                                                                     
  - 在不扩大范围的前提下修复删除与读取链路的一致性问题                                                                  
                                                                                                                        
  ### Action                                                                                                            
  本次改动：                                                                                                            
  - 将 tombstone 从裸 ID 升级为带上下文的作用域记录                                                                     
    - session：`sessionId + workspaceId`                                                                                
    - workspace：`workspaceId + path`                                                                                   
  - 保留旧字段兼容已有磁盘数据                                                                                          
  - 在启动 merge 阶段按 scoped tombstone 过滤 file-only 项                                                              
  - 更新新建/删除入口，精确写入和清理 tombstone                                                                         
  - 让 worktree 恢复逻辑遵守删除语义                                                                                    
  - 顺手复用了 Rust 路径规范化 helper，并简化了 workspace session 计数逻辑                                              
                                                                                                                        
  ### Result                                                                                                            
  结果是：                                                                                                              
  - 已删除 session 不会因旧镜像或残留 worktree 在重启后复活                                                             
  - 已删除 workspace 不会被旧镜像重新补回                                                                               
  - 启动恢复继续保持 local-first，但变得 delete-safe                                                                    
  - numeric id 重用导致误删/误恢复的风险显著下降                                                                        
                                                                                                                        
                                                                                                   
                                                                                                                        
  ### Situation                                                                                                         
  In release builds, session/workspace restoration depended on WebView `localStorage` plus mirrored file-backed UI
  state. Users could hit a case where:                                                                                  
  - old sessions were deleted                               
  - new sessions were created and used                                                                                  
  - after restarting the app, the new sessions disappeared                                                              
  - deleted sessions came back                                                                                          
                                                                                                                        
  The root cause was that tombstones were keyed only by raw `sessionId` / `workspaceId`, and startup merge could        
  reintroduce file-only entries from mirrored state.                                                                    
                                                                                                                        
  ### Task                                                                                                              
  The goal was to:
  - prevent deleted sessions/workspaces from reappearing after restart                                                  
  - preserve local-first restore behavior                                                                               
  - fix the consistency problem in the read/delete path without expanding scope into a broader persistence redesign     
                                                                                                                        
  ### Action                                                                                                            
  This change:                                                                                                          
  - upgrades tombstones from raw ids to scoped references                                                               
    - session: `sessionId + workspaceId`                                                                                
    - workspace: `workspaceId + path`                                                                                   
  - preserves backward compatibility with legacy tombstone fields                                                       
  - filters file-only entries through scoped tombstones during startup merge                                            
  - updates create/delete entry points to write and clear tombstones precisely                                          
  - makes worktree-based recovery respect delete intent                                                                 
  - also reuses a shared Rust path-normalization helper and simplifies workspace session counting                       
                                                                                                                        
  ### Result                                                                                                            
  As a result:                                                                                                          
  - deleted sessions no longer come back after restart because of stale mirrored state                                  
  - deleted workspaces are no longer restored from stale file-backed data                                               
  - startup restore stays local-first but becomes delete-safe                                                           
  - numeric id reuse is much less likely to cause false deletion or false recovery     