### PR TITLE
fix: relax split widget panel width cap

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -656,7 +656,7 @@ export default function App() {
     const startX = event.clientX;
     const startWidth = splitWidgetPanelWidth;
     const minWidth = 220;
-    const maxWidth = 420;
+    const maxWidth = 720;
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
       const nextWidth = Math.min(maxWidth, Math.max(minWidth, Math.round(startWidth - (moveEvent.clientX - startX))));

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -48,7 +48,7 @@ export function normalizeSplitPaneSidebarWidth(width: unknown): number {
 
 export function normalizeSplitWidgetPanelWidth(width: unknown): number {
   if (typeof width !== "number" || !Number.isFinite(width)) return 260;
-  return Math.min(420, Math.max(220, Math.round(width)));
+  return Math.min(720, Math.max(220, Math.round(width)));
 }
 
 export interface SplitWidgetCanvasItem {


### PR DESCRIPTION
Allow the right widget panel in split layout to expand much wider before clamping so it is usable on larger windows.