### PR TITLE
feat: add detachable terminal widget tabs

### DIFF
--- a/src/components/DraggableCard.tsx
+++ b/src/components/DraggableCard.tsx
@@ -47,6 +47,8 @@ function ResizeHandle({
 export function DraggableCard({
   id,
   title,
+  headerActions,
+  dragData,
   gridUnit,
   col,
   row,
@@ -57,6 +59,8 @@ export function DraggableCard({
 }: {
   id: string;
   title: ReactNode;
+  headerActions?: ReactNode;
+  dragData?: Record<string, unknown>;
   gridUnit: number;
   col: number;
   row: number;
@@ -65,7 +69,7 @@ export function DraggableCard({
   onResize?: (deltaCols: number, deltaRows: number) => void;
   children: ReactNode;
 }) {
-  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id });
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id, data: dragData });
   const snappedTransform = transform
     ? {
         x: Math.round(transform.x / gridUnit) * gridUnit,
@@ -110,59 +114,76 @@ export function DraggableCard({
         top: row * gridUnit,
         width: colSpan * gridUnit,
         height: rowSpan * gridUnit,
-        transform: snappedTransform ? CSS.Transform.toString(snappedTransform) : undefined,
+        transform: snappedTransform
+          ? `${CSS.Transform.toString(snappedTransform)} scale(${isDragging ? 1.01 : 1})`
+          : undefined,
         zIndex: isDragging ? 10 : 1,
         display: "flex",
         flexDirection: "column",
         borderRadius: 14,
         overflow: "hidden",
         background: "var(--ci-surface-hi)",
-        border: "1px solid var(--ci-toolbar-border)",
-        boxShadow: isDragging ? "var(--ci-card-shadow-strong)" : "var(--ci-card-shadow)",
+        border: `1px solid ${isDragging ? "var(--ci-accent-bdr)" : "var(--ci-toolbar-border)"}`,
+        boxShadow: isDragging ? "0 0 0 1px var(--ci-accent-bdr), var(--ci-card-shadow-strong)" : "var(--ci-card-shadow)",
+        transition: "border-color 0.15s, box-shadow 0.15s",
       }}
     >
       <div
         style={{
           display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          gap: 8,
-          padding: "8px 10px 6px",
+          flexDirection: "column",
+          gap: headerActions ? 8 : 0,
+          padding: headerActions ? "8px 10px" : "8px 10px 6px",
           background: "var(--ci-toolbar-bg)",
           flexShrink: 0,
         }}
       >
         <div
-          {...listeners}
-          {...attributes}
           style={{
             display: "flex",
             alignItems: "center",
+            justifyContent: "space-between",
             gap: 8,
             minWidth: 0,
-            flex: 1,
-            cursor: isDragging ? "grabbing" : "grab",
-            touchAction: "none",
-            color: "var(--ci-text-muted)",
           }}
         >
-          <span style={{ display: "inline-flex", flexShrink: 0 }}>
-            <DragHandleIcon />
-          </span>
-          <span
+          <div
+            {...listeners}
+            {...attributes}
             style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
               minWidth: 0,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-              fontSize: 10,
-              fontFamily: "monospace",
+              flex: 1,
+              cursor: isDragging ? "grabbing" : "grab",
+              touchAction: "none",
+              color: "var(--ci-text-muted)",
             }}
           >
-            {title}
-          </span>
+            <span style={{ display: "inline-flex", flexShrink: 0 }}>
+              <DragHandleIcon />
+            </span>
+            <span
+              style={{
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                fontSize: 10,
+                fontFamily: "monospace",
+              }}
+            >
+              {title}
+            </span>
+          </div>
         </div>
 
+        {headerActions && (
+          <div style={{ minWidth: 0 }}>
+            {headerActions}
+          </div>
+        )}
       </div>
 
       <div style={{ flex: 1, minHeight: 0, position: "relative" }}>

--- a/src/components/PtyTerminal.tsx
+++ b/src/components/PtyTerminal.tsx
@@ -96,6 +96,13 @@ function getTerminalMetrics() {
   };
 }
 
+function getClampedTerminalSize(term: Terminal) {
+  return {
+    cols: Math.max(term.cols, 20),
+    rows: Math.max(term.rows, 5),
+  };
+}
+
 function wheelDeltaToLines(event: WheelEvent, rows: number): number {
   if (event.deltaY === 0) return 0;
 
@@ -467,9 +474,7 @@ export function PtyTerminal({
       const term = termRef.current;
       term?.focus();
       if (!term) return;
-      const cols = Math.max(term.cols, 20);
-      const rows = Math.max(term.rows, 5);
-      invoke("resize_pty", { sessionId, cols, rows }).catch(() => {});
+      invoke("resize_pty", { sessionId, ...getClampedTerminalSize(term) }).catch(() => {});
     }, 80);
     return () => clearTimeout(t);
   }, [active, sessionId]);
@@ -491,9 +496,7 @@ export function PtyTerminal({
       fit.fit();
       // 仅在面板可见时同步给 Rust，防止收起时 cols/rows 为 0 导致进程崩溃
       if (!activeRef.current) return;
-      const cols = Math.max(term.cols, 20);
-      const rows = Math.max(term.rows, 5);
-      invoke("resize_pty", { sessionId, cols, rows }).catch(() => {});
+      invoke("resize_pty", { sessionId, ...getClampedTerminalSize(term) }).catch(() => {});
     });
     ro.observe(el);
     return () => ro.disconnect();

--- a/src/components/PtyTerminal.tsx
+++ b/src/components/PtyTerminal.tsx
@@ -464,7 +464,12 @@ export function PtyTerminal({
     if (!active) return;
     const t = setTimeout(() => {
       fitRef.current?.fit();
-      termRef.current?.focus();
+      const term = termRef.current;
+      term?.focus();
+      if (!term) return;
+      const cols = Math.max(term.cols, 20);
+      const rows = Math.max(term.rows, 5);
+      invoke("resize_pty", { sessionId, cols, rows }).catch(() => {});
     }, 80);
     return () => clearTimeout(t);
   }, [active, sessionId]);

--- a/src/components/SplitWidgetPanel.tsx
+++ b/src/components/SplitWidgetPanel.tsx
@@ -235,6 +235,38 @@ function removeTabFromWidget(widget: SplitWidgetTerminalItem, tabId: string) {
   };
 }
 
+function detachTerminalTab(
+  items: SplitWidgetCanvasItem[],
+  sourceLayout: SplitWidgetCanvasItem,
+  sourceWidgetId: string,
+  tabId: string
+) {
+  const sourceWidget = items.find(
+    (item): item is SplitWidgetTerminalItem => item.type === "terminal" && item.id === sourceWidgetId
+  );
+  if (!sourceWidget) {
+    return { itemsWithoutSource: items, removedTab: null as SplitWidgetTerminalTab | null };
+  }
+  const { nextWidget, removedTab } = removeTabFromWidget(sourceWidget, tabId);
+  if (!removedTab) {
+    return { itemsWithoutSource: items, removedTab };
+  }
+  return {
+    itemsWithoutSource: items.flatMap((item) => {
+      if (item.id !== sourceWidgetId) return [item];
+      if (!nextWidget) return [];
+      return [{
+        ...nextWidget,
+        col: sourceLayout.col,
+        row: sourceLayout.row,
+        colSpan: sourceLayout.colSpan,
+        rowSpan: sourceLayout.rowSpan,
+      }];
+    }),
+    removedTab,
+  };
+}
+
 function readDragData(value: unknown): SplitWidgetDragData | null {
   if (!value || typeof value !== "object" || !("type" in value)) return null;
   const candidate = value as Partial<SplitWidgetDragData>;
@@ -288,7 +320,7 @@ function getTerminalWidgetAtPoint(
   return null;
 }
 
-function getDetachedPreviewRect(
+function getDetachedTabState(
   items: SplitWidgetCanvasItem[],
   repairedWidgetMap: Map<string, SplitWidgetCanvasItem>,
   sourceWidgetId: string,
@@ -302,27 +334,12 @@ function getDetachedPreviewRect(
   maxRows: number,
   snapToFreeSpace: boolean,
   clampToBounds: boolean
-): SplitWidgetTerminalItem | null {
+): { itemsWithoutSource: SplitWidgetCanvasItem[]; detachedItem: SplitWidgetTerminalItem } | null {
   const sourceLayout = repairedWidgetMap.get(sourceWidgetId);
-  const sourceWidget = items.find(
-    (item): item is SplitWidgetTerminalItem => item.type === "terminal" && item.id === sourceWidgetId
-  );
-  if (!sourceLayout || !sourceWidget) return null;
+  if (!sourceLayout) return null;
 
-  const { nextWidget, removedTab } = removeTabFromWidget(sourceWidget, tabId);
+  const { itemsWithoutSource, removedTab } = detachTerminalTab(items, sourceLayout, sourceWidgetId, tabId);
   if (!removedTab) return null;
-
-  const itemsWithoutSource = items.flatMap((item) => {
-    if (item.id !== sourceWidgetId) return [item];
-    if (!nextWidget) return [];
-    return [{
-      ...nextWidget,
-      col: sourceLayout.col,
-      row: sourceLayout.row,
-      colSpan: sourceLayout.colSpan,
-      rowSpan: sourceLayout.rowSpan,
-    }];
-  });
 
   const occupiedItems = itemsWithoutSource
     .filter((item) => item.visible !== false)
@@ -356,7 +373,9 @@ function getDetachedPreviewRect(
     ? findNearestFreePlacement(detachedCandidate, occupiedItems, maxCols, maxRows)
     : detachedCandidate;
 
-  return resolvedDetached && resolvedDetached.type === "terminal" ? resolvedDetached : null;
+  return resolvedDetached && resolvedDetached.type === "terminal"
+    ? { itemsWithoutSource, detachedItem: resolvedDetached }
+    : null;
 }
 
 function moveTerminalTabToWidget(
@@ -796,7 +815,7 @@ export function SplitWidgetPanel() {
               return;
             }
 
-            setDetachedPreviewRect(getDetachedPreviewRect(
+            setDetachedPreviewRect(getDetachedTabState(
               settings.splitWidgetCanvas.items,
               repairedWidgetMap,
               dragData.widgetId,
@@ -810,7 +829,7 @@ export function SplitWidgetPanel() {
               maxRows,
               true,
               true
-            ));
+            )?.detachedItem ?? null);
           }}
           onDragCancel={() => {
             setActiveDragType(null);
@@ -863,27 +882,7 @@ export function SplitWidgetPanel() {
 
               if (Math.abs(delta.x) < gridUnit && Math.abs(delta.y) < gridUnit) return;
 
-              const sourceWidget = settings.splitWidgetCanvas.items.find(
-                (item): item is SplitWidgetTerminalItem => item.type === "terminal" && item.id === dragData.widgetId
-              );
-              if (!sourceLayout || !sourceWidget) return;
-
-              const { nextWidget, removedTab } = removeTabFromWidget(sourceWidget, dragData.tabId);
-              if (!removedTab) return;
-
-              const itemsWithoutSource = settings.splitWidgetCanvas.items.flatMap((item) => {
-                if (item.id !== dragData.widgetId) return [item];
-                if (!nextWidget) return [];
-                return [{
-                  ...nextWidget,
-                  col: sourceLayout.col,
-                  row: sourceLayout.row,
-                  colSpan: sourceLayout.colSpan,
-                  rowSpan: sourceLayout.rowSpan,
-                }];
-              });
-
-              const resolvedDetached = getDetachedPreviewRect(
+              const detachedState = getDetachedTabState(
                 settings.splitWidgetCanvas.items,
                 repairedWidgetMap,
                 dragData.widgetId,
@@ -899,9 +898,9 @@ export function SplitWidgetPanel() {
                 true
               );
 
-              if (!resolvedDetached) return;
+              if (!detachedState) return;
 
-              patchCanvasItems([...itemsWithoutSource, resolvedDetached], true);
+              patchCanvasItems([...detachedState.itemsWithoutSource, detachedState.detachedItem], true);
               return;
             }
 
@@ -1032,22 +1031,7 @@ export function SplitWidgetPanel() {
                             }));
                           }}
                           onClose={() => {
-                            updateTerminalWidget(widget.id, (current) => {
-                              if (current.tabs.length <= 1) return current;
-                              const closingIndex = current.tabs.findIndex((item) => item.id === tab.id);
-                              if (closingIndex === -1) return current;
-                              const nextTabs = current.tabs.filter((item) => item.id !== tab.id);
-                              if (nextTabs.length === 0) return current;
-                              const fallbackTab = nextTabs[Math.max(0, closingIndex - 1)] ?? nextTabs[closingIndex] ?? nextTabs[0];
-                              const nextActiveTabId = current.activeTabId === tab.id
-                                ? fallbackTab.id
-                                : current.activeTabId;
-                              return {
-                                ...current,
-                                tabs: nextTabs,
-                                activeTabId: nextActiveTabId,
-                              };
-                            });
+                            updateTerminalWidget(widget.id, (current) => removeTabFromWidget(current, tab.id).nextWidget ?? current);
                           }}
                         />
                       );

--- a/src/components/SplitWidgetPanel.tsx
+++ b/src/components/SplitWidgetPanel.tsx
@@ -1,14 +1,53 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { DndContext, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  pointerWithin,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
 import { PtyTerminal } from "./PtyTerminal";
 import { DraggableCard } from "./DraggableCard";
 import { UsageWidgetCard } from "./UsageWidgetCard";
-import { useSettingsStore, isGlassTheme, type SplitWidgetCanvasItem } from "../store/settingsStore";
+import {
+  useSettingsStore,
+  isGlassTheme,
+  type SplitWidgetCanvasItem,
+  type SplitWidgetTerminalItem,
+  type SplitWidgetTerminalTab,
+} from "../store/settingsStore";
 import { useSessionStore } from "../store/sessionStore";
 
 const WIDGET_GAP = 1;
 const PANEL_MARGIN = 1;
 const RIGHT_EDGE_MARGIN = 3;
+
+type SplitWidgetDragData =
+  | { type: "widget-card"; widgetId: string }
+  | { type: "terminal-card"; widgetId: string }
+  | { type: "terminal-tab"; widgetId: string; tabId: string };
+
+type SplitWidgetDropData = { type: "terminal-card-drop"; widgetId: string };
+
+type ActiveDraggedTab = {
+  widgetId: string;
+  tabId: string;
+  title: string;
+  isActive: boolean;
+  sourceCol: number;
+  sourceRow: number;
+  sourceColSpan: number;
+  sourceRowSpan: number;
+  startPointerX: number;
+  startPointerY: number;
+};
+
+const DETACH_TOLERANCE_PX = 12;
 
 function rectsOverlap(a: SplitWidgetCanvasItem, b: SplitWidgetCanvasItem) {
   return a.col < b.col + b.colSpan + WIDGET_GAP
@@ -70,11 +109,23 @@ function repairLayout(items: SplitWidgetCanvasItem[], maxCols: number, maxRows: 
   for (const item of items) {
     const clamped = clampRectToBounds(item, maxCols, maxRows);
     const next = collides(clamped, placed, clamped.id)
-      ? findNearestFreePlacement(clamped, placed, maxCols, maxRows) ?? clamped
+      ? findNearestFreePlacement(clamped, placed, maxCols, maxRows)
       : clamped;
-    placed.push(next);
+    placed.push(next ?? item);
   }
   return placed;
+}
+
+function reconcileCanvasLayout(items: SplitWidgetCanvasItem[], maxCols: number, maxRows: number) {
+  const visibleItems = items.filter((item) => item.visible !== false);
+  const repairedItems = repairLayout(visibleItems, maxCols, maxRows);
+  const repairedMap = new Map(repairedItems.map((item) => [item.id, item]));
+  return items.map((item) => {
+    const repaired = repairedMap.get(item.id);
+    return repaired
+      ? { ...item, col: repaired.col, row: repaired.row, colSpan: repaired.colSpan, rowSpan: repaired.rowSpan }
+      : item;
+  });
 }
 
 function shellQuote(value: string) {
@@ -126,6 +177,399 @@ function expandLayoutToFill(items: SplitWidgetCanvasItem[], maxCols: number, max
   return items.map((item) => current.get(item.id) ?? item);
 }
 
+function stopEvent(event: { preventDefault: () => void; stopPropagation: () => void }) {
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+function sanitizeSessionKey(value: string) {
+  return value.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+function createTerminalTab(tabs: SplitWidgetTerminalTab[]): SplitWidgetTerminalTab {
+  const numericTitles = tabs
+    .map((tab) => Number(tab.title.match(/^Terminal\s+(\d+)$/)?.[1] ?? Number.NaN))
+    .filter((value) => Number.isFinite(value));
+  const nextNumber = numericTitles.length > 0 ? Math.max(...numericTitles) + 1 : tabs.length + 1;
+  const uniqueId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  return {
+    id: `terminal-tab-${uniqueId}`,
+    title: `Terminal ${nextNumber}`,
+    ptySessionKey: `terminal-pty-${uniqueId}`,
+  };
+}
+
+function createTerminalWidgetId() {
+  return `terminal-widget-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function buildWidgetTerminalSessionId(sessionId: string, ptySessionKey: string) {
+  return `widget-${sanitizeSessionKey(sessionId)}-${sanitizeSessionKey(ptySessionKey)}`;
+}
+
+function getFallbackActiveTabId(tabs: SplitWidgetTerminalTab[], removedIndex: number) {
+  const fallback = tabs[Math.max(0, removedIndex - 1)] ?? tabs[removedIndex] ?? tabs[0];
+  return fallback?.id ?? "";
+}
+
+function removeTabFromWidget(widget: SplitWidgetTerminalItem, tabId: string) {
+  const tabIndex = widget.tabs.findIndex((tab) => tab.id === tabId);
+  if (tabIndex === -1) {
+    return { nextWidget: widget, removedTab: null as SplitWidgetTerminalTab | null };
+  }
+  const removedTab = widget.tabs[tabIndex];
+  const nextTabs = widget.tabs.filter((tab) => tab.id !== tabId);
+  if (nextTabs.length === 0) {
+    return { nextWidget: null as SplitWidgetTerminalItem | null, removedTab };
+  }
+  const nextActiveTabId = nextTabs.some((tab) => tab.id === widget.activeTabId)
+    ? widget.activeTabId
+    : getFallbackActiveTabId(nextTabs, tabIndex);
+  return {
+    nextWidget: {
+      ...widget,
+      tabs: nextTabs,
+      activeTabId: nextActiveTabId,
+    },
+    removedTab,
+  };
+}
+
+function readDragData(value: unknown): SplitWidgetDragData | null {
+  if (!value || typeof value !== "object" || !("type" in value)) return null;
+  const candidate = value as Partial<SplitWidgetDragData>;
+  if (candidate.type === "terminal-tab" && typeof candidate.widgetId === "string" && typeof candidate.tabId === "string") {
+    return { type: "terminal-tab", widgetId: candidate.widgetId, tabId: candidate.tabId };
+  }
+  if (candidate.type === "terminal-card" && typeof candidate.widgetId === "string") {
+    return { type: "terminal-card", widgetId: candidate.widgetId };
+  }
+  if (candidate.type === "widget-card" && typeof candidate.widgetId === "string") {
+    return { type: "widget-card", widgetId: candidate.widgetId };
+  }
+  return null;
+}
+
+function readDropData(value: unknown): SplitWidgetDropData | null {
+  if (!value || typeof value !== "object" || !("type" in value)) return null;
+  const candidate = value as Partial<SplitWidgetDropData>;
+  if (candidate.type !== "terminal-card-drop" || typeof candidate.widgetId !== "string") return null;
+  return { type: "terminal-card-drop", widgetId: candidate.widgetId };
+}
+
+function isPointInsideWidget(
+  item: SplitWidgetCanvasItem,
+  x: number,
+  y: number,
+  gridUnit: number,
+  tolerance = 0
+) {
+  const left = item.col * gridUnit - tolerance;
+  const top = item.row * gridUnit - tolerance;
+  const right = (item.col + item.colSpan) * gridUnit + tolerance;
+  const bottom = (item.row + item.rowSpan) * gridUnit + tolerance;
+  return x >= left && x <= right && y >= top && y <= bottom;
+}
+
+function getTerminalWidgetAtPoint(
+  repairedWidgetMap: Map<string, SplitWidgetCanvasItem>,
+  sourceWidgetId: string,
+  x: number,
+  y: number,
+  gridUnit: number,
+  tolerance = 0
+): SplitWidgetTerminalItem | null {
+  for (const item of repairedWidgetMap.values()) {
+    if (item.type !== "terminal" || item.id === sourceWidgetId) continue;
+    if (isPointInsideWidget(item, x, y, gridUnit, tolerance)) {
+      return item;
+    }
+  }
+  return null;
+}
+
+function getDetachedPreviewRect(
+  items: SplitWidgetCanvasItem[],
+  repairedWidgetMap: Map<string, SplitWidgetCanvasItem>,
+  sourceWidgetId: string,
+  tabId: string,
+  pointerX: number,
+  pointerY: number,
+  sourcePointerX: number,
+  sourcePointerY: number,
+  gridUnit: number,
+  maxCols: number,
+  maxRows: number,
+  snapToFreeSpace: boolean,
+  clampToBounds: boolean
+): SplitWidgetTerminalItem | null {
+  const sourceLayout = repairedWidgetMap.get(sourceWidgetId);
+  const sourceWidget = items.find(
+    (item): item is SplitWidgetTerminalItem => item.type === "terminal" && item.id === sourceWidgetId
+  );
+  if (!sourceLayout || !sourceWidget) return null;
+
+  const { nextWidget, removedTab } = removeTabFromWidget(sourceWidget, tabId);
+  if (!removedTab) return null;
+
+  const itemsWithoutSource = items.flatMap((item) => {
+    if (item.id !== sourceWidgetId) return [item];
+    if (!nextWidget) return [];
+    return [{
+      ...nextWidget,
+      col: sourceLayout.col,
+      row: sourceLayout.row,
+      colSpan: sourceLayout.colSpan,
+      rowSpan: sourceLayout.rowSpan,
+    }];
+  });
+
+  const occupiedItems = itemsWithoutSource
+    .filter((item) => item.visible !== false)
+    .map((item) => {
+      const repaired = repairedWidgetMap.get(item.id);
+      return repaired
+        ? { ...item, col: repaired.col, row: repaired.row, colSpan: repaired.colSpan, rowSpan: repaired.rowSpan }
+        : item;
+    });
+
+  const sourceLeftPx = sourceLayout.col * gridUnit;
+  const sourceTopPx = sourceLayout.row * gridUnit;
+  const grabOffsetX = sourcePointerX - sourceLeftPx;
+  const grabOffsetY = sourcePointerY - sourceTopPx;
+
+  const detachedCandidate = (clampToBounds ? clampRectToBounds : (item: SplitWidgetCanvasItem) => item)({
+    id: createTerminalWidgetId(),
+    type: "terminal",
+    col: Math.round((pointerX - grabOffsetX) / gridUnit),
+    row: Math.round((pointerY - grabOffsetY) / gridUnit),
+    colSpan: sourceLayout.colSpan,
+    rowSpan: sourceLayout.rowSpan,
+    visible: true,
+    tabs: [removedTab],
+    activeTabId: removedTab.id,
+  }, maxCols, maxRows);
+
+  const resolvedDetached = !snapToFreeSpace
+    ? detachedCandidate
+    : collides(detachedCandidate, occupiedItems, detachedCandidate.id)
+    ? findNearestFreePlacement(detachedCandidate, occupiedItems, maxCols, maxRows)
+    : detachedCandidate;
+
+  return resolvedDetached && resolvedDetached.type === "terminal" ? resolvedDetached : null;
+}
+
+function moveTerminalTabToWidget(
+  items: SplitWidgetCanvasItem[],
+  sourceWidgetId: string,
+  targetWidgetId: string,
+  tabId: string
+) {
+  if (sourceWidgetId === targetWidgetId) return items;
+
+  let movedTab: SplitWidgetTerminalTab | null = null;
+  const nextItems: SplitWidgetCanvasItem[] = [];
+
+  for (const item of items) {
+    if (item.type !== "terminal") {
+      nextItems.push(item);
+      continue;
+    }
+
+    if (item.id !== sourceWidgetId) {
+      nextItems.push(item);
+      continue;
+    }
+
+    const { nextWidget, removedTab } = removeTabFromWidget(item, tabId);
+    movedTab = removedTab;
+    if (nextWidget) nextItems.push(nextWidget);
+  }
+
+  if (!movedTab) return items;
+
+  let targetFound = false;
+  const finalItems = nextItems.map((item) => {
+    if (item.type === "terminal" && item.id === targetWidgetId) {
+      targetFound = true;
+      return {
+        ...item,
+        tabs: [...item.tabs, movedTab!],
+        activeTabId: movedTab!.id,
+      };
+    }
+    return item;
+  });
+
+  return targetFound ? finalItems : items;
+}
+
+function mergeTerminalWidgets(items: SplitWidgetCanvasItem[], sourceWidgetId: string, targetWidgetId: string) {
+  if (sourceWidgetId === targetWidgetId) return items;
+
+  const sourceWidget = items.find((item) => item.type === "terminal" && item.id === sourceWidgetId);
+  if (!sourceWidget || sourceWidget.type !== "terminal") return items;
+
+  let targetFound = false;
+  const finalItems = items
+    .filter((item) => item.id !== sourceWidgetId)
+    .map((item) => {
+      if (item.type === "terminal" && item.id === targetWidgetId) {
+        targetFound = true;
+        return {
+          ...item,
+          tabs: [...item.tabs, ...sourceWidget.tabs],
+          activeTabId: sourceWidget.tabs.some((tab) => tab.id === sourceWidget.activeTabId)
+            ? sourceWidget.activeTabId
+            : item.activeTabId,
+        };
+      }
+      return item;
+    });
+
+  return targetFound ? finalItems : items;
+}
+
+function TerminalCardDropZone({
+  widgetId,
+  activeDragType,
+  children,
+}: {
+  widgetId: string;
+  activeDragType: SplitWidgetDragData["type"] | null;
+  children: ReactNode;
+}) {
+  const { isOver, setNodeRef } = useDroppable({
+    id: `terminal-card-drop-${widgetId}`,
+    data: { type: "terminal-card-drop", widgetId },
+  });
+  const canAcceptDrop = activeDragType === "terminal-tab" || activeDragType === "terminal-card";
+  const showHint = canAcceptDrop && !isOver;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        minWidth: 0,
+        borderRadius: 10,
+        padding: 2,
+        border: `1px dashed ${isOver ? "var(--ci-accent)" : showHint ? "var(--ci-accent-bdr)" : "transparent"}`,
+        background: isOver ? "var(--ci-accent-bg)" : showHint ? "rgba(63,145,255,0.06)" : "transparent",
+        boxShadow: isOver ? "0 0 0 1px var(--ci-accent-bdr) inset" : "none",
+        transition: "background 0.15s, border-color 0.15s, box-shadow 0.15s",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function TerminalTabChip({
+  widgetId,
+  tab,
+  isActive,
+  onSelect,
+  onClose,
+  canClose,
+}: {
+  widgetId: string;
+  tab: SplitWidgetTerminalTab;
+  isActive: boolean;
+  onSelect: () => void;
+  onClose: () => void;
+  canClose: boolean;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: `terminal-tab-${widgetId}-${tab.id}`,
+    data: { type: "terminal-tab", widgetId, tabId: tab.id },
+  });
+  const showHover = hovered && !isDragging && !isActive;
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        minWidth: 0,
+        padding: "2px 4px 2px 8px",
+        borderRadius: 9,
+        border: `1px solid ${isDragging ? "var(--ci-accent)" : isActive ? "var(--ci-accent-bdr)" : showHover ? "var(--ci-toolbar-border)" : "transparent"}`,
+        background: isDragging
+          ? "rgba(63,145,255,0.14)"
+          : isActive
+          ? "var(--ci-accent-bg)"
+          : showHover
+          ? "rgba(255,255,255,0.06)"
+          : "rgba(255,255,255,0.02)",
+        boxShadow: isDragging ? "0 8px 18px rgba(15,23,42,0.14)" : "none",
+        transform: transform ? CSS.Transform.toString(transform) : undefined,
+        opacity: isDragging ? 0 : 1,
+        zIndex: isDragging ? 2 : 1,
+        cursor: isDragging ? "grabbing" : "grab",
+        touchAction: "none",
+        transition: "background 0.15s, border-color 0.15s, box-shadow 0.15s",
+      }}
+    >
+      <button
+        onClick={(event) => {
+          stopEvent(event);
+          onSelect();
+        }}
+        style={{
+          minWidth: 0,
+          maxWidth: 120,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          background: "none",
+          border: "none",
+          color: isActive ? "var(--ci-accent)" : "var(--ci-text-muted)",
+          cursor: "pointer",
+          fontSize: 11,
+          padding: 0,
+        }}
+      >
+        {tab.title}
+      </button>
+      {canClose && (
+        <button
+          onPointerDown={stopEvent}
+          onClick={(event) => {
+            stopEvent(event);
+            onClose();
+          }}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 16,
+            height: 16,
+            borderRadius: 999,
+            background: "none",
+            border: "none",
+            color: isActive ? "var(--ci-accent)" : "var(--ci-text-dim)",
+            cursor: "pointer",
+            fontSize: 12,
+            padding: 0,
+            lineHeight: 1,
+            flexShrink: 0,
+          }}
+          aria-label={`关闭 ${tab.title}`}
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}
+
 export function SplitWidgetPanel() {
   const { settings, patchSettings } = useSettingsStore();
   const isGlass = useSettingsStore((s) => isGlassTheme(s.settings.theme));
@@ -134,15 +578,15 @@ export function SplitWidgetPanel() {
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
   const panelRef = useRef<HTMLDivElement | null>(null);
   const [panelBounds, setPanelBounds] = useState({ width: 0, height: 0 });
+  const [activeDragType, setActiveDragType] = useState<SplitWidgetDragData["type"] | null>(null);
+  const [activeDraggedTab, setActiveDraggedTab] = useState<ActiveDraggedTab | null>(null);
+  const [detachedPreviewRect, setDetachedPreviewRect] = useState<SplitWidgetTerminalItem | null>(null);
 
   const session = useMemo(
     () => sessions.find((item) => item.id === expandedSessionId) ?? null,
     [expandedSessionId, sessions]
   );
   const terminalWorkdir = session?.worktreePath ?? session?.workdir ?? "";
-  const widgetTerminalSessionId = session
-    ? `widget-${session.id}-${terminalWorkdir.replace(/[^a-zA-Z0-9_-]/g, "_")}`
-    : "widget-none";
   const terminalCommand = navigator.userAgent.toLowerCase().includes("windows") ? "cmd.exe" : "sh";
   const terminalArgs = navigator.userAgent.toLowerCase().includes("windows")
     ? ["/K", `cd /d "${terminalWorkdir}"`]
@@ -152,6 +596,30 @@ export function SplitWidgetPanel() {
   const maxCols = Math.max(12, Math.floor(panelBounds.width / gridUnit));
   const maxRows = Math.max(10, Math.floor(panelBounds.height / gridUnit));
   const repairedWidgets = useMemo(() => repairLayout(widgets, maxCols, maxRows), [widgets, maxCols, maxRows]);
+  const repairedWidgetMap = useMemo(() => new Map(repairedWidgets.map((item) => [item.id, item])), [repairedWidgets]);
+
+  const patchCanvasItems = useCallback((items: SplitWidgetCanvasItem[], clearFilledSnapshot = false) => {
+    patchSettings({
+      splitWidgetCanvas: {
+        ...settings.splitWidgetCanvas,
+        items: reconcileCanvasLayout(items, maxCols, maxRows),
+        filledSnapshot: clearFilledSnapshot ? null : (settings.splitWidgetCanvas.filledSnapshot ?? null),
+      },
+    });
+  }, [maxCols, maxRows, patchSettings, settings.splitWidgetCanvas]);
+
+  const updateTerminalWidget = useCallback((widgetId: string, updater: (widget: SplitWidgetTerminalItem) => SplitWidgetTerminalItem) => {
+    patchSettings({
+      splitWidgetCanvas: {
+        ...settings.splitWidgetCanvas,
+        items: settings.splitWidgetCanvas.items.map((item) => (
+          item.id === widgetId && item.type === "terminal"
+            ? updater(item)
+            : item
+        )),
+      },
+    });
+  }, [patchSettings, settings.splitWidgetCanvas]);
 
   useEffect(() => {
     const element = panelRef.current;
@@ -260,8 +728,192 @@ export function SplitWidgetPanel() {
       {repairedWidgets.length > 0 ? (
         <DndContext
           sensors={sensors}
-          onDragEnd={({ active, delta }) => {
-            const current = repairedWidgets.find((item) => item.id === active.id);
+          collisionDetection={pointerWithin}
+          onDragStart={({ active, activatorEvent }) => {
+            const dragData = readDragData(active.data.current);
+            setActiveDragType(dragData?.type ?? null);
+            if (dragData?.type === "terminal-tab") {
+              const widget = settings.splitWidgetCanvas.items.find(
+                (item): item is SplitWidgetTerminalItem => item.type === "terminal" && item.id === dragData.widgetId
+              );
+              const tab = widget?.tabs.find((item) => item.id === dragData.tabId);
+              const sourceLayout = repairedWidgetMap.get(dragData.widgetId);
+              const panelRect = panelRef.current?.getBoundingClientRect();
+              const pointerEvent = activatorEvent instanceof PointerEvent ? activatorEvent : null;
+              setActiveDraggedTab(tab && sourceLayout && panelRect ? {
+                widgetId: dragData.widgetId,
+                tabId: tab.id,
+                title: tab.title,
+                isActive: widget?.activeTabId === tab.id,
+                sourceCol: sourceLayout.col,
+                sourceRow: sourceLayout.row,
+                sourceColSpan: sourceLayout.colSpan,
+                sourceRowSpan: sourceLayout.rowSpan,
+                startPointerX: (pointerEvent?.clientX ?? panelRect.left + sourceLayout.col * gridUnit) - panelRect.left,
+                startPointerY: (pointerEvent?.clientY ?? panelRect.top + sourceLayout.row * gridUnit) - panelRect.top,
+              } : null);
+            } else {
+              setActiveDraggedTab(null);
+            }
+            setDetachedPreviewRect(null);
+          }}
+          onDragMove={({ active, delta }) => {
+            const dragData = readDragData(active.data.current);
+            if (dragData?.type !== "terminal-tab") {
+              setDetachedPreviewRect(null);
+              return;
+            }
+
+            const sourceLayout = repairedWidgetMap.get(dragData.widgetId);
+            if (!sourceLayout || !activeDraggedTab) {
+              setDetachedPreviewRect(null);
+              return;
+            }
+
+            const pointerX = activeDraggedTab.startPointerX + delta.x;
+            const pointerY = activeDraggedTab.startPointerY + delta.y;
+
+            if (isPointInsideWidget(sourceLayout, pointerX, pointerY, gridUnit, DETACH_TOLERANCE_PX)) {
+              setDetachedPreviewRect(null);
+              return;
+            }
+            const hoveredTerminal = getTerminalWidgetAtPoint(
+              repairedWidgetMap,
+              dragData.widgetId,
+              pointerX,
+              pointerY,
+              gridUnit,
+              DETACH_TOLERANCE_PX
+            );
+
+            if (hoveredTerminal) {
+              setDetachedPreviewRect(null);
+              return;
+            }
+
+            if (Math.abs(delta.x) < gridUnit && Math.abs(delta.y) < gridUnit) {
+              setDetachedPreviewRect(null);
+              return;
+            }
+
+            setDetachedPreviewRect(getDetachedPreviewRect(
+              settings.splitWidgetCanvas.items,
+              repairedWidgetMap,
+              dragData.widgetId,
+              dragData.tabId,
+              pointerX,
+              pointerY,
+              activeDraggedTab.startPointerX,
+              activeDraggedTab.startPointerY,
+              gridUnit,
+              maxCols,
+              maxRows,
+              true,
+              true
+            ));
+          }}
+          onDragCancel={() => {
+            setActiveDragType(null);
+            setActiveDraggedTab(null);
+            setDetachedPreviewRect(null);
+          }}
+          onDragEnd={(event: DragEndEvent) => {
+            const { active, over, delta } = event;
+            const dragData = readDragData(active.data.current);
+            const dropData = readDropData(over?.data.current);
+            setActiveDragType(null);
+            setActiveDraggedTab(null);
+            setDetachedPreviewRect(null);
+            if (!dragData) return;
+
+            if (dragData.type === "terminal-tab") {
+              const sourceLayout = repairedWidgetMap.get(dragData.widgetId);
+              if (!sourceLayout || !activeDraggedTab) return;
+
+              const pointerX = activeDraggedTab.startPointerX + delta.x;
+              const pointerY = activeDraggedTab.startPointerY + delta.y;
+
+              if (isPointInsideWidget(sourceLayout, pointerX, pointerY, gridUnit, DETACH_TOLERANCE_PX)) {
+                return;
+              }
+
+              const hoveredTerminal = getTerminalWidgetAtPoint(
+                repairedWidgetMap,
+                dragData.widgetId,
+                pointerX,
+                pointerY,
+                gridUnit,
+                DETACH_TOLERANCE_PX
+              );
+
+              if (hoveredTerminal) {
+                const nextItems = moveTerminalTabToWidget(
+                  settings.splitWidgetCanvas.items,
+                  dragData.widgetId,
+                  hoveredTerminal.id,
+                  dragData.tabId
+                );
+                if (nextItems !== settings.splitWidgetCanvas.items) {
+                  patchCanvasItems(nextItems, true);
+                }
+                return;
+              }
+
+              if (dropData?.widgetId === dragData.widgetId) return;
+
+              if (Math.abs(delta.x) < gridUnit && Math.abs(delta.y) < gridUnit) return;
+
+              const sourceWidget = settings.splitWidgetCanvas.items.find(
+                (item): item is SplitWidgetTerminalItem => item.type === "terminal" && item.id === dragData.widgetId
+              );
+              if (!sourceLayout || !sourceWidget) return;
+
+              const { nextWidget, removedTab } = removeTabFromWidget(sourceWidget, dragData.tabId);
+              if (!removedTab) return;
+
+              const itemsWithoutSource = settings.splitWidgetCanvas.items.flatMap((item) => {
+                if (item.id !== dragData.widgetId) return [item];
+                if (!nextWidget) return [];
+                return [{
+                  ...nextWidget,
+                  col: sourceLayout.col,
+                  row: sourceLayout.row,
+                  colSpan: sourceLayout.colSpan,
+                  rowSpan: sourceLayout.rowSpan,
+                }];
+              });
+
+              const resolvedDetached = getDetachedPreviewRect(
+                settings.splitWidgetCanvas.items,
+                repairedWidgetMap,
+                dragData.widgetId,
+                dragData.tabId,
+                pointerX,
+                pointerY,
+                activeDraggedTab.startPointerX,
+                activeDraggedTab.startPointerY,
+                gridUnit,
+                maxCols,
+                maxRows,
+                true,
+                true
+              );
+
+              if (!resolvedDetached) return;
+
+              patchCanvasItems([...itemsWithoutSource, resolvedDetached], true);
+              return;
+            }
+
+            if (dragData.type === "terminal-card" && dropData && dropData.widgetId !== dragData.widgetId) {
+              const nextItems = mergeTerminalWidgets(settings.splitWidgetCanvas.items, dragData.widgetId, dropData.widgetId);
+              if (nextItems !== settings.splitWidgetCanvas.items) {
+                patchCanvasItems(nextItems, true);
+              }
+              return;
+            }
+
+            const current = repairedWidgetMap.get(dragData.widgetId);
             if (!current) return;
             const colDelta = Math.round(delta.x / gridUnit);
             const rowDelta = Math.round(delta.y / gridUnit);
@@ -277,7 +929,7 @@ export function SplitWidgetPanel() {
               splitWidgetCanvas: {
                 ...settings.splitWidgetCanvas,
                 items: settings.splitWidgetCanvas.items.map((item) =>
-                  item.id === active.id
+                  item.id === dragData.widgetId
                     ? { ...item, col: resolved.col, row: resolved.row, colSpan: resolved.colSpan, rowSpan: resolved.rowSpan }
                     : item
                 ),
@@ -285,65 +937,246 @@ export function SplitWidgetPanel() {
             });
           }}
         >
-          {repairedWidgets.map((widget) => (
-            <DraggableCard
-              key={widget.id}
-              id={widget.id}
-              title={widget.type === "terminal" ? (terminalWorkdir || "Terminal") : null}
-              gridUnit={gridUnit}
-              col={widget.col}
-              row={widget.row}
-              colSpan={widget.colSpan}
-              rowSpan={widget.rowSpan}
-              onResize={(deltaCols, deltaRows) => {
-                const candidate = clampRectToBounds({
-                  ...widget,
-                  colSpan: Math.max(12, widget.colSpan + deltaCols),
-                  rowSpan: Math.max(10, widget.rowSpan + deltaRows),
-                }, maxCols, maxRows);
-                let resolved = candidate;
-                if (collides(candidate, repairedWidgets, widget.id)) {
-                  let nextColSpan = candidate.colSpan;
-                  let nextRowSpan = candidate.rowSpan;
-                  while ((nextColSpan > widget.colSpan || nextRowSpan > widget.rowSpan) && collides({ ...candidate, colSpan: nextColSpan, rowSpan: nextRowSpan }, repairedWidgets, widget.id)) {
-                    if (nextColSpan > widget.colSpan) nextColSpan -= 1;
-                    if (nextRowSpan > widget.rowSpan) nextRowSpan -= 1;
-                  }
-                  resolved = {
-                    ...candidate,
-                    colSpan: Math.max(12, nextColSpan),
-                    rowSpan: Math.max(10, nextRowSpan),
-                  };
-                  if (collides(resolved, repairedWidgets, widget.id)) {
-                    resolved = widget;
-                  }
-                }
-                patchSettings({
-                  splitWidgetCanvas: {
-                    ...settings.splitWidgetCanvas,
-                    items: settings.splitWidgetCanvas.items.map((item) =>
-                      item.id === widget.id
-                        ? { ...item, col: resolved.col, row: resolved.row, colSpan: resolved.colSpan, rowSpan: resolved.rowSpan }
-                        : item
-                    ),
-                  },
-                });
+          {detachedPreviewRect && (
+            <div
+              style={{
+                position: "absolute",
+                left: detachedPreviewRect.col * gridUnit,
+                top: detachedPreviewRect.row * gridUnit,
+                width: detachedPreviewRect.colSpan * gridUnit,
+                height: detachedPreviewRect.rowSpan * gridUnit,
+                borderRadius: 14,
+                border: "1px dashed var(--ci-accent)",
+                background: "rgba(63,145,255,0.08)",
+                boxShadow: "0 12px 24px rgba(15,23,42,0.10)",
+                pointerEvents: "none",
+                zIndex: 9,
               }}
             >
-              {widget.type === "terminal" && session && terminalWorkdir ? (
-                <PtyTerminal
-                  key={widgetTerminalSessionId}
-                  sessionId={widgetTerminalSessionId}
-                  command={terminalCommand}
-                  args={terminalArgs}
-                  workdir={terminalWorkdir}
-                  active
-                />
-              ) : widget.type === "usage" ? (
-                <UsageWidgetCard />
-              ) : null}
-            </DraggableCard>
-          ))}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  height: 34,
+                  padding: "0 10px",
+                  borderBottom: "1px dashed rgba(63,145,255,0.35)",
+                  color: "var(--ci-accent)",
+                  fontSize: 10,
+                  fontFamily: "monospace",
+                  background: "rgba(63,145,255,0.06)",
+                }}
+              >
+                Terminal
+              </div>
+            </div>
+          )}
+          <DragOverlay dropAnimation={null}>
+            {activeDraggedTab ? (
+              <div
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                  minWidth: 0,
+                  maxWidth: 140,
+                  padding: "4px 8px",
+                  borderRadius: 9,
+                  border: `1px solid ${activeDraggedTab.isActive ? "var(--ci-accent)" : "var(--ci-accent-bdr)"}`,
+                  background: activeDraggedTab.isActive ? "var(--ci-accent-bg)" : "rgba(63,145,255,0.10)",
+                  color: activeDraggedTab.isActive ? "var(--ci-accent)" : "var(--ci-text)",
+                  fontSize: 11,
+                  boxShadow: "0 12px 24px rgba(15,23,42,0.16)",
+                  pointerEvents: "none",
+                }}
+              >
+                <span
+                  style={{
+                    minWidth: 0,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {activeDraggedTab.title}
+                </span>
+              </div>
+            ) : null}
+          </DragOverlay>
+          {repairedWidgets.map((widget) => {
+            const headerActions = widget.type === "terminal" ? (
+              <TerminalCardDropZone widgetId={widget.id} activeDragType={activeDragType}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+                  <div style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
+                    minWidth: 0,
+                    flex: 1,
+                    overflowX: "auto",
+                    scrollbarWidth: "none",
+                  }}>
+                    {widget.tabs.map((tab) => {
+                      const isActive = tab.id === widget.activeTabId;
+                      return (
+                        <TerminalTabChip
+                          key={tab.id}
+                          widgetId={widget.id}
+                          tab={tab}
+                          isActive={isActive}
+                          canClose={widget.tabs.length > 1}
+                          onSelect={() => {
+                            if (tab.id === widget.activeTabId) return;
+                            updateTerminalWidget(widget.id, (current) => ({
+                              ...current,
+                              activeTabId: tab.id,
+                            }));
+                          }}
+                          onClose={() => {
+                            updateTerminalWidget(widget.id, (current) => {
+                              if (current.tabs.length <= 1) return current;
+                              const closingIndex = current.tabs.findIndex((item) => item.id === tab.id);
+                              if (closingIndex === -1) return current;
+                              const nextTabs = current.tabs.filter((item) => item.id !== tab.id);
+                              if (nextTabs.length === 0) return current;
+                              const fallbackTab = nextTabs[Math.max(0, closingIndex - 1)] ?? nextTabs[closingIndex] ?? nextTabs[0];
+                              const nextActiveTabId = current.activeTabId === tab.id
+                                ? fallbackTab.id
+                                : current.activeTabId;
+                              return {
+                                ...current,
+                                tabs: nextTabs,
+                                activeTabId: nextActiveTabId,
+                              };
+                            });
+                          }}
+                        />
+                      );
+                    })}
+                  </div>
+
+                  <button
+                    onPointerDown={stopEvent}
+                    onClick={(event) => {
+                      stopEvent(event);
+                      updateTerminalWidget(widget.id, (current) => {
+                        const nextTab = createTerminalTab(current.tabs);
+                        return {
+                          ...current,
+                          tabs: [...current.tabs, nextTab],
+                          activeTabId: nextTab.id,
+                        };
+                      });
+                    }}
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      width: 22,
+                      height: 22,
+                      borderRadius: 8,
+                      background: "none",
+                      border: "1px solid var(--ci-toolbar-border)",
+                      color: "var(--ci-text-muted)",
+                      cursor: "pointer",
+                      fontSize: 14,
+                      padding: 0,
+                      flexShrink: 0,
+                    }}
+                    aria-label="新建终端标签页"
+                  >
+                    +
+                  </button>
+                </div>
+              </TerminalCardDropZone>
+            ) : undefined;
+
+            return (
+              <DraggableCard
+                key={widget.id}
+                id={widget.id}
+                title={widget.type === "terminal" ? (terminalWorkdir || "Terminal") : null}
+                headerActions={headerActions}
+                dragData={{
+                  type: widget.type === "terminal" ? "terminal-card" : "widget-card",
+                  widgetId: widget.id,
+                }}
+                gridUnit={gridUnit}
+                col={widget.col}
+                row={widget.row}
+                colSpan={widget.colSpan}
+                rowSpan={widget.rowSpan}
+                onResize={(deltaCols, deltaRows) => {
+                  const candidate = clampRectToBounds({
+                    ...widget,
+                    colSpan: Math.max(12, widget.colSpan + deltaCols),
+                    rowSpan: Math.max(10, widget.rowSpan + deltaRows),
+                  }, maxCols, maxRows);
+                  let resolved = candidate;
+                  if (collides(candidate, repairedWidgets, widget.id)) {
+                    let nextColSpan = candidate.colSpan;
+                    let nextRowSpan = candidate.rowSpan;
+                    while ((nextColSpan > widget.colSpan || nextRowSpan > widget.rowSpan) && collides({ ...candidate, colSpan: nextColSpan, rowSpan: nextRowSpan }, repairedWidgets, widget.id)) {
+                      if (nextColSpan > widget.colSpan) nextColSpan -= 1;
+                      if (nextRowSpan > widget.rowSpan) nextRowSpan -= 1;
+                    }
+                    resolved = {
+                      ...candidate,
+                      colSpan: Math.max(12, nextColSpan),
+                      rowSpan: Math.max(10, nextRowSpan),
+                    };
+                    if (collides(resolved, repairedWidgets, widget.id)) {
+                      resolved = widget;
+                    }
+                  }
+                  patchSettings({
+                    splitWidgetCanvas: {
+                      ...settings.splitWidgetCanvas,
+                      items: settings.splitWidgetCanvas.items.map((item) =>
+                        item.id === widget.id
+                          ? { ...item, col: resolved.col, row: resolved.row, colSpan: resolved.colSpan, rowSpan: resolved.rowSpan }
+                          : item
+                      ),
+                    },
+                  });
+                }}
+              >
+                {widget.type === "terminal" ? (
+                  <div style={{ position: "relative", width: "100%", height: "100%" }}>
+                    {widget.tabs.map((tab) => {
+                      const ptySessionId = session
+                        ? buildWidgetTerminalSessionId(session.id, tab.ptySessionKey)
+                        : `widget-none-${tab.ptySessionKey}`;
+                      const isActiveTab = tab.id === widget.activeTabId;
+                      return (
+                        <div
+                          key={ptySessionId}
+                          style={{
+                            position: "absolute",
+                            inset: 0,
+                            opacity: isActiveTab ? 1 : 0,
+                            pointerEvents: isActiveTab ? "auto" : "none",
+                            zIndex: isActiveTab ? 1 : 0,
+                          }}
+                        >
+                          {session && terminalWorkdir ? (
+                            <PtyTerminal
+                              sessionId={ptySessionId}
+                              command={terminalCommand}
+                              args={terminalArgs}
+                              workdir={terminalWorkdir}
+                              active={isActiveTab}
+                            />
+                          ) : null}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : widget.type === "usage" ? (
+                  <UsageWidgetCard />
+                ) : null}
+              </DraggableCard>
+            );
+          })}
         </DndContext>
       ) : (
         <div style={{

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -51,7 +51,13 @@ export function normalizeSplitWidgetPanelWidth(width: unknown): number {
   return Math.min(420, Math.max(220, Math.round(width)));
 }
 
-export interface SplitWidgetCanvasItem {
+export interface SplitWidgetTerminalTab {
+  id: string;
+  title: string;
+  ptySessionKey: string;
+}
+
+interface SplitWidgetCanvasItemBase {
   id: string;
   type: "terminal" | "usage";
   col: number;
@@ -61,10 +67,44 @@ export interface SplitWidgetCanvasItem {
   visible: boolean;
 }
 
+export interface SplitWidgetTerminalItem extends SplitWidgetCanvasItemBase {
+  type: "terminal";
+  tabs: SplitWidgetTerminalTab[];
+  activeTabId: string;
+}
+
+export interface SplitWidgetUsageItem extends SplitWidgetCanvasItemBase {
+  type: "usage";
+}
+
+export type SplitWidgetCanvasItem = SplitWidgetTerminalItem | SplitWidgetUsageItem;
+
 export interface SplitWidgetCanvas {
   cellSize: number;
   items: SplitWidgetCanvasItem[];
   filledSnapshot?: SplitWidgetCanvasItem[] | null;
+}
+
+function createDefaultTerminalTab(index = 1): SplitWidgetTerminalTab {
+  return {
+    id: `terminal-tab-${index}`,
+    title: `Terminal ${index}`,
+    ptySessionKey: `terminal-pty-${index}`,
+  };
+}
+
+function normalizeSplitWidgetTerminalTab(tab: unknown, index: number): SplitWidgetTerminalTab | null {
+  if (!tab || typeof tab !== "object") return null;
+  const candidate = tab as Partial<SplitWidgetTerminalTab>;
+  const fallback = createDefaultTerminalTab(index + 1);
+  const id = typeof candidate.id === "string" && candidate.id.trim() ? candidate.id : fallback.id;
+  return {
+    id,
+    title: typeof candidate.title === "string" && candidate.title.trim() ? candidate.title.trim() : fallback.title,
+    ptySessionKey: typeof candidate.ptySessionKey === "string" && candidate.ptySessionKey.trim()
+      ? candidate.ptySessionKey.trim()
+      : `terminal-pty-${id}`,
+  };
 }
 
 function normalizeSplitWidgetCanvasItem(item: unknown): SplitWidgetCanvasItem | null {
@@ -72,7 +112,7 @@ function normalizeSplitWidgetCanvasItem(item: unknown): SplitWidgetCanvasItem | 
   const candidate = item as Partial<SplitWidgetCanvasItem>;
   if (candidate.type !== "terminal" && candidate.type !== "usage") return null;
   if (!candidate.id || typeof candidate.id !== "string") return null;
-  return {
+  const base = {
     id: candidate.id,
     type: candidate.type,
     col: typeof candidate.col === "number" && Number.isFinite(candidate.col) ? Math.max(1, Math.round(candidate.col)) : 1,
@@ -80,6 +120,29 @@ function normalizeSplitWidgetCanvasItem(item: unknown): SplitWidgetCanvasItem | 
     colSpan: typeof candidate.colSpan === "number" && Number.isFinite(candidate.colSpan) ? Math.max(12, Math.round(candidate.colSpan)) : 18,
     rowSpan: typeof candidate.rowSpan === "number" && Number.isFinite(candidate.rowSpan) ? Math.max(10, Math.round(candidate.rowSpan)) : 13,
     visible: candidate.visible !== false,
+  };
+
+  if (candidate.type === "terminal") {
+    const terminalCandidate = item as Partial<SplitWidgetTerminalItem>;
+    const tabs = Array.isArray(terminalCandidate.tabs)
+      ? terminalCandidate.tabs
+        .map(normalizeSplitWidgetTerminalTab)
+        .filter((tab): tab is SplitWidgetTerminalTab => tab !== null)
+      : [];
+    const normalizedTabs = tabs.length > 0 ? tabs : [createDefaultTerminalTab()];
+    return {
+      ...base,
+      type: "terminal",
+      tabs: normalizedTabs,
+      activeTabId: typeof terminalCandidate.activeTabId === "string" && normalizedTabs.some((tab) => tab.id === terminalCandidate.activeTabId)
+        ? terminalCandidate.activeTabId
+        : normalizedTabs[0].id,
+    };
+  }
+
+  return {
+    ...base,
+    type: "usage",
   };
 }
 
@@ -91,7 +154,18 @@ export function normalizeSplitWidgetCanvas(canvas: unknown): SplitWidgetCanvas {
   const normalizedItems = items.length > 0 ? [...items] : [];
 
   if (!normalizedItems.some((item) => item.type === "terminal")) {
-    normalizedItems.unshift({ id: "terminal-widget-1", type: "terminal", col: 2, row: 16, colSpan: 18, rowSpan: 13, visible: true });
+    const defaultTab = createDefaultTerminalTab();
+    normalizedItems.unshift({
+      id: "terminal-widget-1",
+      type: "terminal",
+      col: 2,
+      row: 16,
+      colSpan: 18,
+      rowSpan: 13,
+      visible: true,
+      tabs: [defaultTab],
+      activeTabId: defaultTab.id,
+    });
   }
 
   if (!normalizedItems.some((item) => item.type === "usage")) {
@@ -180,10 +254,23 @@ const DEFAULT_SETTINGS: Settings = {
   splitWidgetPanelCollapsed: true,
   splitWidgetCanvas: {
     cellSize: 12,
-    items: [
-      { id: "terminal-widget-1", type: "terminal", col: 2, row: 16, colSpan: 18, rowSpan: 13, visible: true },
-      { id: "usage-widget-1", type: "usage", col: 2, row: 2, colSpan: 18, rowSpan: 10, visible: true },
-    ],
+    items: (() => {
+      const defaultTab = createDefaultTerminalTab();
+      return [
+        {
+          id: "terminal-widget-1",
+          type: "terminal",
+          col: 2,
+          row: 16,
+          colSpan: 18,
+          rowSpan: 13,
+          visible: true,
+          tabs: [defaultTab],
+          activeTabId: defaultTab.id,
+        },
+        { id: "usage-widget-1", type: "usage", col: 2, row: 2, colSpan: 18, rowSpan: 10, visible: true },
+      ];
+    })(),
     filledSnapshot: null,
   },
 };

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -93,6 +93,37 @@ function createDefaultTerminalTab(index = 1): SplitWidgetTerminalTab {
   };
 }
 
+function createDefaultTerminalWidget(): SplitWidgetTerminalItem {
+  const defaultTab = createDefaultTerminalTab();
+  return {
+    id: "terminal-widget-1",
+    type: "terminal",
+    col: 2,
+    row: 16,
+    colSpan: 18,
+    rowSpan: 13,
+    visible: true,
+    tabs: [defaultTab],
+    activeTabId: defaultTab.id,
+  };
+}
+
+function createDefaultUsageWidget(): SplitWidgetUsageItem {
+  return {
+    id: "usage-widget-1",
+    type: "usage",
+    col: 2,
+    row: 2,
+    colSpan: 18,
+    rowSpan: 10,
+    visible: true,
+  };
+}
+
+function createDefaultSplitWidgetItems(): SplitWidgetCanvasItem[] {
+  return [createDefaultTerminalWidget(), createDefaultUsageWidget()];
+}
+
 function normalizeSplitWidgetTerminalTab(tab: unknown, index: number): SplitWidgetTerminalTab | null {
   if (!tab || typeof tab !== "object") return null;
   const candidate = tab as Partial<SplitWidgetTerminalTab>;
@@ -154,22 +185,11 @@ export function normalizeSplitWidgetCanvas(canvas: unknown): SplitWidgetCanvas {
   const normalizedItems = items.length > 0 ? [...items] : [];
 
   if (!normalizedItems.some((item) => item.type === "terminal")) {
-    const defaultTab = createDefaultTerminalTab();
-    normalizedItems.unshift({
-      id: "terminal-widget-1",
-      type: "terminal",
-      col: 2,
-      row: 16,
-      colSpan: 18,
-      rowSpan: 13,
-      visible: true,
-      tabs: [defaultTab],
-      activeTabId: defaultTab.id,
-    });
+    normalizedItems.unshift(createDefaultTerminalWidget());
   }
 
   if (!normalizedItems.some((item) => item.type === "usage")) {
-    normalizedItems.push({ id: "usage-widget-1", type: "usage", col: 2, row: 2, colSpan: 18, rowSpan: 10, visible: true });
+    normalizedItems.push(createDefaultUsageWidget());
   }
 
   return {
@@ -254,23 +274,7 @@ const DEFAULT_SETTINGS: Settings = {
   splitWidgetPanelCollapsed: true,
   splitWidgetCanvas: {
     cellSize: 12,
-    items: (() => {
-      const defaultTab = createDefaultTerminalTab();
-      return [
-        {
-          id: "terminal-widget-1",
-          type: "terminal",
-          col: 2,
-          row: 16,
-          colSpan: 18,
-          rowSpan: 13,
-          visible: true,
-          tabs: [defaultTab],
-          activeTabId: defaultTab.id,
-        },
-        { id: "usage-widget-1", type: "usage", col: 2, row: 2, colSpan: 18, rowSpan: 10, visible: true },
-      ];
-    })(),
+    items: createDefaultSplitWidgetItems(),
     filledSnapshot: null,
   },
 };


### PR DESCRIPTION
Let terminal widget tabs split into standalone cards and merge back into other terminal cards so the split layout behaves more like VS Code. Reuse stable PTY identities and align drag previews with final placement to preserve sessions and reduce jarring drag transitions.