### PR TITLE
fix: support resizing split widgets from all edges

### DIFF
--- a/src/components/DraggableCard.tsx
+++ b/src/components/DraggableCard.tsx
@@ -2,6 +2,8 @@ import type { PointerEvent as ReactPointerEvent, ReactNode } from "react";
 import { useDraggable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 
+export type ResizeEdge = "left" | "right" | "top" | "bottom" | "top-left" | "top-right" | "bottom-left" | "corner";
+
 function DragHandleIcon() {
   return (
     <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
@@ -20,14 +22,24 @@ function ResizeHandle({
   cursor,
   onPointerDown,
 }: {
-  edge: "right" | "bottom" | "corner";
+  edge: ResizeEdge;
   cursor: string;
   onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
 }) {
-  const style = edge === "right"
+  const style = edge === "left"
+    ? { top: 0, left: -4, bottom: 0, width: 8 }
+    : edge === "right"
     ? { top: 0, right: -4, bottom: 0, width: 8 }
+    : edge === "top"
+    ? { left: 0, right: 0, top: -4, height: 8 }
     : edge === "bottom"
     ? { left: 0, right: 0, bottom: -4, height: 8 }
+    : edge === "top-left"
+    ? { left: -4, top: -4, width: 12, height: 12 }
+    : edge === "top-right"
+    ? { right: -4, top: -4, width: 12, height: 12 }
+    : edge === "bottom-left"
+    ? { left: -4, bottom: -4, width: 12, height: 12 }
     : { right: -4, bottom: -4, width: 12, height: 12 };
 
   return (
@@ -68,7 +80,7 @@ export function DraggableCard({
   row: number;
   colSpan: number;
   rowSpan: number;
-  onResize?: (deltaCols: number, deltaRows: number) => void;
+  onResize?: (edge: ResizeEdge, deltaCols: number, deltaRows: number) => void;
   children: ReactNode;
 }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id, data: dragData });
@@ -81,7 +93,7 @@ export function DraggableCard({
       }
     : null;
 
-  const handleResizePointerDown = (edge: "right" | "bottom" | "corner") => (event: ReactPointerEvent<HTMLDivElement>) => {
+  const handleResizePointerDown = (edge: ResizeEdge) => (event: ReactPointerEvent<HTMLDivElement>) => {
     if (!onResize) return;
     event.preventDefault();
     event.stopPropagation();
@@ -89,13 +101,19 @@ export function DraggableCard({
     const startY = event.clientY;
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
-      const deltaCols = edge === "right" || edge === "corner"
-        ? Math.round((moveEvent.clientX - startX) / gridUnit)
+      const deltaX = Math.round((moveEvent.clientX - startX) / gridUnit);
+      const deltaY = Math.round((moveEvent.clientY - startY) / gridUnit);
+      const deltaCols = edge === "left" || edge === "top-left" || edge === "bottom-left"
+        ? -deltaX
+        : edge === "right" || edge === "top-right" || edge === "corner"
+        ? deltaX
         : 0;
-      const deltaRows = edge === "bottom" || edge === "corner"
-        ? Math.round((moveEvent.clientY - startY) / gridUnit)
+      const deltaRows = edge === "top" || edge === "top-left" || edge === "top-right"
+        ? -deltaY
+        : edge === "bottom" || edge === "bottom-left" || edge === "corner"
+        ? deltaY
         : 0;
-      onResize(deltaCols, deltaRows);
+      onResize(edge, deltaCols, deltaRows);
     };
 
     const handlePointerUp = () => {
@@ -200,8 +218,13 @@ export function DraggableCard({
 
       {onResize && (
         <>
+          <ResizeHandle edge="left" cursor="ew-resize" onPointerDown={handleResizePointerDown("left")} />
           <ResizeHandle edge="right" cursor="ew-resize" onPointerDown={handleResizePointerDown("right")} />
+          <ResizeHandle edge="top" cursor="ns-resize" onPointerDown={handleResizePointerDown("top")} />
           <ResizeHandle edge="bottom" cursor="ns-resize" onPointerDown={handleResizePointerDown("bottom")} />
+          <ResizeHandle edge="top-left" cursor="nwse-resize" onPointerDown={handleResizePointerDown("top-left")} />
+          <ResizeHandle edge="top-right" cursor="nesw-resize" onPointerDown={handleResizePointerDown("top-right")} />
+          <ResizeHandle edge="bottom-left" cursor="nesw-resize" onPointerDown={handleResizePointerDown("bottom-left")} />
           <ResizeHandle edge="corner" cursor="nwse-resize" onPointerDown={handleResizePointerDown("corner")} />
         </>
       )}

--- a/src/components/SplitWidgetPanel.tsx
+++ b/src/components/SplitWidgetPanel.tsx
@@ -11,7 +11,7 @@ import {
   type DragEndEvent,
 } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
-import { DraggableCard } from "./DraggableCard";
+import { DraggableCard, type ResizeEdge } from "./DraggableCard";
 import { SplitDockOutlet, useSplitSwapSnapshot } from "./SplitSwapLayout";
 import {
   useSettingsStore,
@@ -133,6 +133,44 @@ function insetRect(item: SplitWidgetCanvasItem, maxCols: number, maxRows: number
     colSpan: Math.max(12, item.colSpan),
     rowSpan: Math.max(10, item.rowSpan),
   }, maxCols - RIGHT_EDGE_MARGIN + 1, maxRows - PANEL_MARGIN + 1);
+}
+
+function resizeWidgetRect(
+  widget: SplitWidgetCanvasItem,
+  edge: ResizeEdge,
+  deltaCols: number,
+  deltaRows: number,
+  maxCols: number,
+  maxRows: number
+) {
+  const minColSpan = 12;
+  const minRowSpan = 10;
+  const right = widget.col + widget.colSpan;
+  const bottom = widget.row + widget.rowSpan;
+
+  let next = { ...widget };
+
+  if (edge === "left" || edge === "top-left" || edge === "bottom-left") {
+    const requestedCol = widget.col - deltaCols;
+    next.col = Math.max(PANEL_MARGIN, Math.min(requestedCol, right - minColSpan));
+    next.colSpan = right - next.col;
+  }
+
+  if (edge === "right" || edge === "top-right" || edge === "corner") {
+    next.colSpan = Math.max(minColSpan, widget.colSpan + deltaCols);
+  }
+
+  if (edge === "top" || edge === "top-left" || edge === "top-right") {
+    const requestedRow = widget.row - deltaRows;
+    next.row = Math.max(PANEL_MARGIN, Math.min(requestedRow, bottom - minRowSpan));
+    next.rowSpan = bottom - next.row;
+  }
+
+  if (edge === "bottom" || edge === "bottom-left" || edge === "corner") {
+    next.rowSpan = Math.max(minRowSpan, widget.rowSpan + deltaRows);
+  }
+
+  return clampRectToBounds(next, maxCols, maxRows);
 }
 
 function expandLayoutToFill(items: SplitWidgetCanvasItem[], maxCols: number, maxRows: number) {
@@ -1123,25 +1161,19 @@ export function SplitWidgetPanel() {
                 row={widget.row}
                 colSpan={widget.colSpan}
                 rowSpan={widget.rowSpan}
-                onResize={(deltaCols, deltaRows) => {
-                  const candidate = clampRectToBounds({
-                    ...widget,
-                    colSpan: Math.max(12, widget.colSpan + deltaCols),
-                    rowSpan: Math.max(10, widget.rowSpan + deltaRows),
-                  }, maxCols, maxRows);
+                onResize={(edge, deltaCols, deltaRows) => {
+                  const candidate = resizeWidgetRect(widget, edge, deltaCols, deltaRows, maxCols, maxRows);
                   let resolved = candidate;
                   if (collides(candidate, repairedWidgets, widget.id)) {
-                    let nextColSpan = candidate.colSpan;
-                    let nextRowSpan = candidate.rowSpan;
-                    while ((nextColSpan > widget.colSpan || nextRowSpan > widget.rowSpan) && collides({ ...candidate, colSpan: nextColSpan, rowSpan: nextRowSpan }, repairedWidgets, widget.id)) {
-                      if (nextColSpan > widget.colSpan) nextColSpan -= 1;
-                      if (nextRowSpan > widget.rowSpan) nextRowSpan -= 1;
+                    let nextDeltaCols = deltaCols;
+                    let nextDeltaRows = deltaRows;
+                    while ((nextDeltaCols !== 0 || nextDeltaRows !== 0) && collides(resizeWidgetRect(widget, edge, nextDeltaCols, nextDeltaRows, maxCols, maxRows), repairedWidgets, widget.id)) {
+                      if (nextDeltaCols > 0) nextDeltaCols -= 1;
+                      else if (nextDeltaCols < 0) nextDeltaCols += 1;
+                      if (nextDeltaRows > 0) nextDeltaRows -= 1;
+                      else if (nextDeltaRows < 0) nextDeltaRows += 1;
                     }
-                    resolved = {
-                      ...candidate,
-                      colSpan: Math.max(12, nextColSpan),
-                      rowSpan: Math.max(10, nextRowSpan),
-                    };
+                    resolved = resizeWidgetRect(widget, edge, nextDeltaCols, nextDeltaRows, maxCols, maxRows);
                     if (collides(resolved, repairedWidgets, widget.id)) {
                       resolved = widget;
                     }


### PR DESCRIPTION
Allow split widget cards to resize from the left and top edges and add the remaining corner handles so card resizing works from every side.