### PR TITLE
fix: stabilize session worktree identity

### DIFF
--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -1,9 +1,23 @@
-use std::{fs, path::Path};
+use std::{fs, path::Path, time::{SystemTime, UNIX_EPOCH}};
 
 use crate::runtime_scope::session_worktree_root_dir;
 use crate::util::{background_command, expand_path, normalize_expanded_path};
 
 // ── 辅助函数 ──────────────────────────────────────────────────────
+pub fn session_branch_prefix() -> String {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0);
+    let token = format!("{:06x}", millis % 0x1000000);
+    format!("ci/{token}")
+}
+
+pub fn session_branch_name(prefix: &str, session_id: &str) -> String {
+    format!("{prefix}/session-{session_id}")
+}
+
 /// 从 worktree 目录的 HEAD 文件读取分支名
 pub fn read_worktree_branch(worktree_path: &Path) -> Option<String> {
     // worktree 中的 HEAD 格式：ref: refs/heads/<branch>
@@ -229,7 +243,8 @@ pub async fn setup_session_worktree(
             session_worktree_root_dir(),
             session_id_clone
         );
-        let branch = format!("ci/session-{}", session_id_clone);
+        let branch_prefix = session_branch_prefix();
+        let branch = session_branch_name(&branch_prefix, &session_id_clone);
 
         // 幂等：先清理同名的旧 worktree/分支
         let _ = background_command("git")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -250,6 +250,7 @@ pub fn run() {
             ui_state::clear_deleted_items,
             ui_state::save_ui_state,
             ui_state::remove_ui_state,
+            ui_state::reserve_session_id,
             ui_state::recover_workspace_sessions,
             ui_state::save_recovery_binding,
             usage::refresh_runner_usage,

--- a/src-tauri/src/ui_state.rs
+++ b/src-tauri/src/ui_state.rs
@@ -15,6 +15,8 @@ use crate::util::{background_command, home_dir, normalize_expanded_path};
 const UI_STATE_DIR: &str = "ui-state";
 const DELETED_UI_STATE_KEY: &str = "code-bar-deleted-items";
 const RECOVERY_BINDINGS_KEY: &str = "code-bar-recovery-bindings";
+const SESSION_ID_STATE_KEY: &str = "code-bar-session-id-state";
+static SESSION_ID_STATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -108,6 +110,17 @@ struct RecoveryBinding {
     worktree_path: Option<String>,
     #[serde(default)]
     updated_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionIdState {
+    #[serde(default = "default_next_session_id")]
+    next_session_id: u64,
+}
+
+fn default_next_session_id() -> u64 {
+    1
 }
 
 fn normalize_optional_string(value: Option<String>) -> Option<String> {
@@ -344,6 +357,26 @@ fn read_recovery_bindings(app: &tauri::AppHandle) -> Result<Vec<RecoveryBinding>
     serde_json::from_str::<Vec<RecoveryBinding>>(&content)
         .map(|items| items.into_iter().filter_map(RecoveryBinding::normalized).collect())
         .map_err(|e| format!("解析恢复绑定失败: {e}"))
+}
+
+fn read_session_id_state(app: &tauri::AppHandle) -> Result<SessionIdState, String> {
+    let Some(content) = read_ui_state(app, SESSION_ID_STATE_KEY)? else {
+        return Ok(SessionIdState::default());
+    };
+
+    serde_json::from_str::<SessionIdState>(&content)
+        .map(|state| SessionIdState {
+            next_session_id: state.next_session_id.max(default_next_session_id()),
+        })
+        .map_err(|e| format!("解析 session ID 状态失败: {e}"))
+}
+
+fn write_session_id_state(app: &tauri::AppHandle, state: &SessionIdState) -> Result<(), String> {
+    let payload = serde_json::to_string(&SessionIdState {
+        next_session_id: state.next_session_id.max(default_next_session_id()),
+    })
+    .map_err(|e| format!("序列化 session ID 状态失败: {e}"))?;
+    write_ui_state(app, SESSION_ID_STATE_KEY, &payload)
 }
 
 fn write_recovery_bindings(app: &tauri::AppHandle, bindings: &[RecoveryBinding]) -> Result<(), String> {
@@ -722,6 +755,106 @@ fn numeric_session_id(name: &str) -> Option<String> {
     }
 }
 
+fn parse_numeric_session_id(value: &str) -> Option<u64> {
+    value.trim().parse::<u64>().ok()
+}
+
+fn collect_known_session_id_floor(
+    deleted_state: &DeletedUiState,
+    recovery_bindings: &[RecoveryBinding],
+    workspaces: &[RecoverWorkspaceInput],
+    existing_session_ids: &[String],
+) -> u64 {
+    let mut max_seen = 0_u64;
+
+    for id in existing_session_ids {
+        if let Some(value) = parse_numeric_session_id(id) {
+            max_seen = max_seen.max(value);
+        }
+    }
+
+    for id in &deleted_state.session_ids {
+        if let Some(value) = parse_numeric_session_id(id) {
+            max_seen = max_seen.max(value);
+        }
+    }
+
+    for entry in &deleted_state.sessions {
+        if let Some(value) = parse_numeric_session_id(&entry.session_id) {
+            max_seen = max_seen.max(value);
+        }
+    }
+
+    for binding in recovery_bindings {
+        if let Some(value) = parse_numeric_session_id(&binding.session_id) {
+            max_seen = max_seen.max(value);
+        }
+    }
+
+    for workspace in workspaces {
+        let normalized_workspace_path = normalize_path(Some(workspace.workspace_path.clone())).unwrap_or_default();
+        if normalized_workspace_path.is_empty() {
+            continue;
+        }
+
+        let repo_root = PathBuf::from(&normalized_workspace_path);
+        let Some(parent) = repo_root.parent() else {
+            continue;
+        };
+
+        let worktree_root = parent.join(session_worktree_root_dir());
+        let Ok(entries) = fs::read_dir(&worktree_root) else {
+            continue;
+        };
+
+        for entry in entries.flatten() {
+            let worktree_path = entry.path();
+            if !worktree_path.is_dir() {
+                continue;
+            }
+
+            let Some(dir_name) = worktree_path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            let Some(session_id) = numeric_session_id(dir_name) else {
+                continue;
+            };
+            let Some(value) = parse_numeric_session_id(&session_id) else {
+                continue;
+            };
+
+            max_seen = max_seen.max(value);
+        }
+    }
+
+    max_seen
+}
+
+#[tauri::command]
+pub fn reserve_session_id(
+    app: tauri::AppHandle,
+    workspaces: Vec<RecoverWorkspaceInput>,
+    existing_session_ids: Vec<String>,
+) -> Result<String, String> {
+    let _lock = SESSION_ID_STATE_LOCK
+        .lock()
+        .map_err(|e| format!("锁定 session ID 状态失败: {e}"))?;
+    let deleted_state = read_deleted_ui_state(&app)?;
+    let recovery_bindings = read_recovery_bindings(&app)?;
+    let mut state = read_session_id_state(&app)?;
+    let floor = collect_known_session_id_floor(
+        &deleted_state,
+        &recovery_bindings,
+        &workspaces,
+        &existing_session_ids,
+    );
+
+    let candidate = state.next_session_id.max(floor.saturating_add(1));
+    state.next_session_id = candidate.saturating_add(1).max(default_next_session_id());
+    write_session_id_state(&app, &state)?;
+    Ok(candidate.to_string())
+}
+
 #[tauri::command]
 pub fn load_ui_states(
     app: tauri::AppHandle,
@@ -969,8 +1102,7 @@ pub fn recover_workspace_sessions(
                 continue;
             };
 
-            let branch_name = current_branch(&worktree_path)
-                .or_else(|| Some(format!("ci/session-{session_id}")));
+            let branch_name = current_branch(&worktree_path);
             let workdir = worktree_path.to_string_lossy().to_string();
             let current_task = hint.current_task.clone();
 

--- a/src/components/SessionDetail.tsx
+++ b/src/components/SessionDetail.tsx
@@ -431,7 +431,7 @@ function SessionPanel({ sessionId, isOpen, onClose, presentation, showHeader }: 
       ["CODE_BAR_WORKSPACE_ID", session.workspaceId],
       ["CODE_BAR_WORKSPACE_NAME", workspace?.name ?? ""],
       ["CODE_BAR_CONCURRENT_SESSIONS", String(siblingSessions.length)],
-      ["CODE_BAR_SUGGESTED_BRANCH", `ci/session-${session.id}`],
+      ["CODE_BAR_SUGGESTED_BRANCH", session.branchName ?? `ci/session-${session.id}`],
       // Worktree 信息：告知 AI CLI 当前在独立 worktree 工作，不用自己创建分支
       ...(session.worktreePath ? [
         ["CODE_BAR_WORKTREE_PATH", session.worktreePath] as [string, string],

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -223,7 +223,7 @@ function SessionCard({
               overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
               maxWidth: 140,
             }}>
-              ⎇ {session.branchName.replace("ci/", "")}
+              ⎇ s-{session.id}
             </span>
             {session.diffFiles.length > 0 && (
               <>
@@ -435,6 +435,7 @@ export function SessionList() {
     updateSession,
   } = useSessionStore();
   const { activeWorkspaceId } = useWorkspaceStore();
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
   const activeWorkspace = useWorkspaceStore((s) =>
     s.workspaces.find((w) => w.id === activeWorkspaceId)
   );
@@ -470,7 +471,30 @@ export function SessionList() {
 
   const handleNewSession = async () => {
     if (!activeWorkspace) return;
-    const id = addSession(activeWorkspace.id, activeWorkspace.path, undefined, { ...runner });
+
+    let id: string;
+    if ("__TAURI_INTERNALS__" in window) {
+      try {
+        id = await invoke<string>("reserve_session_id", {
+          workspaces: workspaces.map((workspace) => ({
+            workspaceId: workspace.id,
+            workspacePath: workspace.path,
+          })),
+          existingSessionIds: sessions.map((session) => session.id),
+        });
+      } catch (e) {
+        console.warn("[ui-state] reserve session id failed:", e);
+        return;
+      }
+    } else {
+      const maxId = sessions
+        .map((session) => Number(session.id))
+        .filter((value) => !Number.isNaN(value))
+        .reduce((max, value) => Math.max(max, value), 0);
+      id = String(maxId + 1);
+    }
+
+    addSession(id, activeWorkspace.id, activeWorkspace.path, undefined, { ...runner });
     setActiveSession(id);
     setExpandedSession(id);
 

--- a/src/store/sessionStore.ts
+++ b/src/store/sessionStore.ts
@@ -41,7 +41,7 @@ export interface ClaudeSession {
   output: string[];
   runner: RunnerConfig;
   pid?: number;
-  branchName?: string;     // AI 在本 session 中使用的 git 分支名（如 ci/session-3）
+  branchName?: string;     // AI 在本 session 中使用的 git 分支名（如 ci/1a2b3c/session-3）
   baseBranch?: string;     // 任务开始时的基础分支（如 main/master）
   worktreePath?: string;   // git worktree 路径
   providerSessionId?: string; // 绑定的 provider 原生会话 ID（用于 codex/claude resume）
@@ -59,7 +59,7 @@ interface SessionStore {
   // 不持久化，每次应用启动重置；持久化的 session 重新打开时从 worktreePath 推断
   worktreeReadyIds: Set<string>;
 
-  addSession: (workspaceId: string, workdir: string, name: string | undefined, runner: RunnerConfig) => string;
+  addSession: (id: string, workspaceId: string, workdir: string, name: string | undefined, runner: RunnerConfig) => string;
   removeSession: (id: string) => void;
   setActiveSession: (id: string | null) => void;
   updateSession: (id: string, patch: Partial<ClaudeSession>) => void;
@@ -76,8 +76,6 @@ interface SessionStore {
 }
 
 // ── 工厂函数 ─────────────────────────────────────────────────
-
-let _counter = 1;
 
 const STATUS_PRIORITY: Partial<Record<SessionStatus, number>> = {
   waiting: 0,
@@ -143,12 +141,10 @@ function hydrateRunnerConfig(runner: RunnerConfig): RunnerConfig {
 }
 
 function makeSession(
-  overrides: Partial<Omit<ClaudeSession, "runner">> & { workspaceId: string; workdir: string; runner: RunnerConfig }
+  overrides: Partial<Omit<ClaudeSession, "runner">> & { id: string; workspaceId: string; workdir: string; runner: RunnerConfig }
 ): ClaudeSession {
-  const id = String(_counter++);
   return {
-    id,
-    name: `会话 ${id}`,
+    name: `会话 ${overrides.id}`,
     status: "idle",
     currentTask: "",
     createdAt: Date.now(),
@@ -172,8 +168,9 @@ export const useSessionStore = create<SessionStore>()(
       splitCardItemIdsBySlot: {},
       worktreeReadyIds: new Set<string>(),
 
-      addSession: (workspaceId, workdir, name, runner) => {
+      addSession: (id, workspaceId, workdir, name, runner) => {
         const s = makeSession({
+          id,
           workspaceId,
           workdir,
           ...(name ? { name } : {}),
@@ -439,14 +436,10 @@ export const useSessionStore = create<SessionStore>()(
         activeSessionId: state.activeSessionId,
         sessionOrderByWorkspace: state.sessionOrderByWorkspace,
       }),
-      // 恢复时：修复 _counter，并将已有 worktreePath 的 session 标记为 worktreeReady
+      // 恢复时：将已有 worktreePath 的 session 标记为 worktreeReady
       // 这些 session 的 worktree 可能已存在（或被孤儿清理），但不再新建——直接用持久化路径
       onRehydrateStorage: () => (state) => {
         if (!state) return;
-        const ids = state.sessions.map((s) => Number(s.id)).filter((n) => !isNaN(n));
-        if (ids.length > 0) {
-          _counter = Math.max(...ids) + 1;
-        }
         // 有 worktreePath 的持久化 session：worktree 已在文件系统中（由启动时的清理机制保证有效性）
         // 直接标记为 ready，不重新创建
         const readyIds = new Set<string>(


### PR DESCRIPTION
Reserve session IDs in persisted Tauri state so deleted or recovered sessions can't reuse old IDs, and namespace session worktree branches to avoid colliding with remote ci/session-x refs.