### PR TITLE
feat: simplify split workbench startup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,8 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { consumeSuppressedEditorReveal, filterVisibleExplorerDirectories, reloadExplorerDirectories, reloadVisibleDirectories, revealExplorerPath } from "./services/editorCommands";
 import { setLiquidGlassEffect, GlassMaterialVariant } from "tauri-plugin-liquid-glass-api";
 import { motion } from "framer-motion";
-import { TitleBar } from "./components/TitleBar";
-import { StatusBar } from "./components/StatusBar";
 import { WorkspaceStack } from "./components/WorkspaceStack";
 import { SessionList } from "./components/SessionList";
-import { SessionDetail } from "./components/SessionDetail";
 import { SplitWidgetPanel } from "./components/SplitWidgetPanel";
 import { SplitSwapProvider } from "./components/SplitSwapLayout";
 import { WorkbenchSidebar } from "./workbench/WorkbenchSidebar";
@@ -79,9 +76,7 @@ export default function App() {
   const focusSession = useWorkbenchStore((s) => s.focusSession);
   const focusedSessionId = useWorkbenchStore((s) => s.focusedSessionId);
   const isGlass = isGlassTheme(settings.theme);
-  const isOriginalLayout = settings.layoutMode === "original";
-  const overlaySessionOpen = isOriginalLayout && expandedSessionId !== null;
-  const isSubPageOpen = settingsOpen || overlaySessionOpen;
+  const isSubPageOpen = settingsOpen;
   const refreshInFlightRef = useRef<Record<string, Promise<void> | null>>({});
   const refreshQueuedRef = useRef<Record<string, boolean>>({});
   const refreshQueuedOptionsRef = useRef<Record<string, { reloadExplorer?: boolean; reloadDirs?: string[] } | undefined>>({});
@@ -587,25 +582,21 @@ export default function App() {
         closeSettings();
         return;
       }
-      if (!isOriginalLayout && sidebarSection !== "sessions") {
+      if (sidebarSection !== "sessions") {
         useWorkbenchStore.getState().resetWorkbenchMode();
         return;
       }
-      if (isOriginalLayout && expandedSessionId !== null) return;
       invoke("close_popup").catch(() => {});
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [settingsOpen, closeSettings, isOriginalLayout, expandedSessionId, sidebarSection]);
+  }, [settingsOpen, closeSettings, sidebarSection]);
 
   // ── 浮窗位置 / 大小记忆：用户拖动/调整后防抖 500ms 写盘 ──
   // 注意：只在基础状态（非展开）下保存，展开状态是临时的，不应覆盖记忆。
   // expandedSessionId 不为 null 表示终端面板已展开。
   const boundsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const suppressBoundsPersistenceRef = useRef(overlaySessionOpen);
-  useEffect(() => {
-    suppressBoundsPersistenceRef.current = overlaySessionOpen;
-  }, [overlaySessionOpen]);
+  const suppressBoundsPersistenceRef = useRef(false);
 
   useEffect(() => {
     if (!("__TAURI_INTERNALS__" in window)) return;
@@ -1002,8 +993,6 @@ export default function App() {
 
   return (
     <>
-      {isOriginalLayout && <SessionDetail mode="overlay" />}
-
       <div style={{
         width: "100vw",
         height: "100vh",
@@ -1103,15 +1092,7 @@ export default function App() {
           }}>
             <Settings />
 
-            {isOriginalLayout ? (
-              !isSubPageOpen && (
-                <>
-                  <TitleBar />
-                  {menuContent}
-                  <StatusBar session={activeSession} />
-                </>
-              )
-            ) : (
+            {!isSubPageOpen && (
               <SplitSwapProvider
                 sessionDetailEmptyState={
                   <div style={{

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -433,7 +433,6 @@ export function SessionList() {
   const runner = sanitizeRunnerConfig(useSettingsStore((s) => s.settings.runner));
   const settings = useSettingsStore((s) => s.settings);
   const isGlass = isGlassTheme(settings.theme);
-  const isSplitLayout = settings.layoutMode === "split";
   const [pendingDeleteSessionId, setPendingDeleteSessionId] = useState<string | null>(null);
   const textShadow = isGlass ? "var(--ci-glass-text-shadow)" : "none";
 
@@ -641,15 +640,11 @@ export function SessionList() {
                       isOpened={session.id === expandedSessionId}
                       accentColor={accentColor}
                       isGlass={isGlass}
-                      showExpandButton={!isSplitLayout}
+                      showExpandButton={false}
                       isDeleteConfirming={pendingDeleteSessionId === session.id}
                       onClick={() => {
                         setPendingDeleteSessionId(null);
-                        if (isSplitLayout) {
-                          showSessionSurface(session.id);
-                          return;
-                        }
-                        setActiveSession(session.id);
+                        showSessionSurface(session.id);
                       }}
                       onCancelDelete={() => {
                         setPendingDeleteSessionId(null);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useSettingsStore, type ThemeMode, type LayoutMode, type SplitWidgetCanvasItem, isGlassTheme } from "../store/settingsStore";
+import { useSettingsStore, type ThemeMode, type SplitWidgetCanvasItem, isGlassTheme } from "../store/settingsStore";
 
 const C = {
   surface:   "var(--ci-surface)",
@@ -58,7 +58,6 @@ function AppearanceTab() {
   const { settings, patchSettings } = useSettingsStore();
 
   type ThemeOption = ThemeMode;
-  type LayoutOption = LayoutMode;
 
   const themeOptions: {
     value: ThemeOption;
@@ -104,26 +103,6 @@ function AppearanceTab() {
       card: "rgba(255,255,255,0.62)",
       accent: "#4f7bff",
       textColor: "#243347",
-    },
-  ];
-
-  const layoutOptions: {
-    value: LayoutOption;
-    label: string;
-    desc: string;
-    preview: string;
-  }[] = [
-    {
-      value: "original",
-      label: "原始布局",
-      desc: "菜单页与终端详情分开显示，展开终端时覆盖主内容。",
-      preview: "▔▔▔▔\n菜单\n列表\nDiff",
-    },
-    {
-      value: "split",
-      label: "分栏布局",
-      desc: "左侧持续显示菜单，右侧显示当前终端详情。",
-      preview: "▔▔▔▔┆▔▔▔▔▔▔\n菜单  ┆   PTY\n列表  ┆ 终端详情\nDiff  ┆ 输出/输入",
     },
   ];
 
@@ -253,121 +232,6 @@ function AppearanceTab() {
         </div>
       </div>
 
-      <div>
-        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: C.textDim, marginBottom: 10 }}>
-          布局
-        </div>
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 12 }}>
-          {layoutOptions.map((opt) => {
-            const active = settings.layoutMode === opt.value;
-            return (
-              <button
-                key={opt.value}
-                onClick={() => patchSettings({ layoutMode: opt.value })}
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: 12,
-                  padding: 12,
-                  background: active ? "linear-gradient(180deg, var(--ci-surface-hi), var(--ci-surface))" : C.surface,
-                  border: `1px solid ${active ? C.accentBdr : C.border}`,
-                  borderRadius: 18,
-                  cursor: "pointer",
-                  textAlign: "left",
-                  transition: "transform 0.16s, border-color 0.16s, box-shadow 0.16s, background 0.16s",
-                  boxShadow: active
-                    ? `0 0 0 3px ${C.accentBg}, var(--ci-card-shadow-strong)`
-                    : "none",
-                  transform: active ? "translateY(-1px)" : "translateY(0)",
-                }}
-              >
-                <div style={{
-                  height: 118,
-                  borderRadius: 14,
-                  border: `1px solid ${C.border}`,
-                  background: "linear-gradient(180deg, var(--ci-surface-hi), var(--ci-surface))",
-                  padding: 14,
-                  boxSizing: "border-box",
-                  display: "flex",
-                  alignItems: "stretch",
-                  gap: opt.value === "split" ? 10 : 0,
-                  color: C.textMuted,
-                  fontSize: 12,
-                  fontWeight: 600,
-                  whiteSpace: "pre-line",
-                }}>
-                  {opt.value === "split" ? (
-                    <>
-                      <div style={{
-                        width: "42%",
-                        borderRadius: 10,
-                        border: `1px solid ${C.border}`,
-                        background: "var(--ci-surface)",
-                        padding: 10,
-                        boxSizing: "border-box",
-                      }}>
-                        {"菜单\n列表\nDiff"}
-                      </div>
-                      <div style={{
-                        flex: 1,
-                        borderRadius: 10,
-                        border: `1px solid ${C.accentBdr}`,
-                        background: "var(--ci-accent-bg)",
-                        color: C.accent,
-                        padding: 10,
-                        boxSizing: "border-box",
-                      }}>
-                        {"PTY\n输出 / 输入"}
-                      </div>
-                    </>
-                  ) : (
-                    <div style={{
-                      width: "100%",
-                      borderRadius: 10,
-                      border: `1px solid ${C.border}`,
-                      background: "var(--ci-surface)",
-                      padding: 10,
-                      boxSizing: "border-box",
-                    }}>
-                      {opt.preview}
-                    </div>
-                  )}
-                </div>
-
-                <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 12 }}>
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: C.textDim, marginBottom: 4 }}>
-                      {active ? "Current" : "Layout"}
-                    </div>
-                    <div style={{ fontSize: 14, fontWeight: active ? 700 : 600, color: active ? C.accent : C.text }}>
-                      {opt.label}
-                    </div>
-                    <div style={{ fontSize: 11, color: C.textDim, marginTop: 4, lineHeight: 1.5 }}>
-                      {opt.desc}
-                    </div>
-                  </div>
-                  <div style={{
-                    minWidth: 20,
-                    height: 20,
-                    padding: active ? "0 8px" : 0,
-                    borderRadius: 999,
-                    border: `1px solid ${active ? C.accentBdr : "transparent"}`,
-                    background: active ? C.accentBg : "transparent",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    color: active ? C.accent : C.textDim,
-                    fontSize: 11,
-                    fontWeight: 700,
-                  }}>
-                    {active ? "已选" : "○"}
-                  </div>
-                </div>
-              </button>
-            );
-          })}
-        </div>
-      </div>
     </div>
   );
 }
@@ -542,16 +406,12 @@ function resolveVisibleSettingsTab(tab: string): VisibleSettingsTab {
 }
 
 export default function Settings() {
-  const { settings, settingsOpen, closeSettings, activeTab, setTab } = useSettingsStore();
+  const { settingsOpen, closeSettings, activeTab, setTab } = useSettingsStore();
   const isGlass = useSettingsStore((s) => isGlassTheme(s.settings.theme));
   const textShadow = isGlass ? "var(--ci-glass-text-shadow)" : "none";
   const strongTextShadow = isGlass ? "var(--ci-glass-text-shadow-strong)" : "none";
-  const visibleTab = settings.layoutMode !== "split" && activeTab === "components"
-    ? "appearance"
-    : resolveVisibleSettingsTab(activeTab);
-  const navItems = settings.layoutMode === "split"
-    ? SETTINGS_NAV_ITEMS
-    : SETTINGS_NAV_ITEMS.filter((item) => item.value !== "components");
+  const visibleTab = resolveVisibleSettingsTab(activeTab);
+  const navItems = SETTINGS_NAV_ITEMS;
 
   if (!settingsOpen) return null;
 

--- a/src/components/SplitSwapLayout.tsx
+++ b/src/components/SplitSwapLayout.tsx
@@ -17,6 +17,7 @@ import {
   type SplitWidgetCanvasItem,
   type SplitWidgetTerminalItem,
 } from "../store/settingsStore";
+import { resetWorkbenchMode } from "../services/workbenchCommands";
 import { useSessionStore } from "../store/sessionStore";
 import { useWorkspaceStore } from "../store/workspaceStore";
 
@@ -565,16 +566,28 @@ export function SplitDetailHost() {
         {item.kind === "terminal" && <SplitStaticTerminalTabs itemId={item.id} />}
         {item.kind === "session-detail" && expandedSessionId && (
           <button
-            onClick={() => setExpandedSession(null)}
+            onClick={() => {
+              setExpandedSession(null);
+              resetWorkbenchMode();
+            }}
+            onMouseEnter={e => {
+              e.currentTarget.style.color = "var(--ci-text)";
+              e.currentTarget.style.opacity = "0.8";
+            }}
+            onMouseLeave={e => {
+              e.currentTarget.style.color = "var(--ci-text-muted)";
+              e.currentTarget.style.opacity = "1";
+            }}
             style={{
-              background: "var(--ci-btn-ghost-bg)",
-              border: "1px solid var(--ci-toolbar-border)",
-              borderRadius: 7,
+              background: "none",
+              border: "none",
               color: "var(--ci-text-muted)",
               cursor: "pointer",
               fontSize: 11,
-              padding: "4px 8px",
+              fontWeight: 600,
+              padding: "4px 2px",
               flexShrink: 0,
+              transition: "color 0.12s, opacity 0.12s",
             }}
           >
             收起

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -25,7 +25,6 @@ export interface ApiKeys {
 }
 
 export type ThemeMode = "light" | "dark" | "glass" | "system";
-export type LayoutMode = "original" | "split";
 
 export function isGlassTheme(theme: ThemeMode): theme is "glass" {
   return theme === "glass";
@@ -35,10 +34,6 @@ export function normalizeThemeMode(theme: string | undefined): ThemeMode {
   if (theme === "liquid") return "glass";
   if (theme === "dark" || theme === "glass" || theme === "system") return theme;
   return "light";
-}
-
-export function normalizeLayoutMode(layoutMode: string | undefined): LayoutMode {
-  return layoutMode === "split" ? "split" : "original";
 }
 
 export function normalizeSplitPaneSidebarWidth(width: unknown): number {
@@ -208,7 +203,6 @@ export interface Settings {
   runnerProfiles: RunnerProfiles;
   apiKeys: ApiKeys;
   theme: ThemeMode;
-  layoutMode: LayoutMode;
   splitPaneSidebarWidth: number;
   splitWidgetPanelWidth: number;
   splitWidgetPanelCollapsed: boolean;
@@ -268,7 +262,6 @@ const DEFAULT_SETTINGS: Settings = {
     openai: "",
   },
   theme: "light",
-  layoutMode: "original",
   splitPaneSidebarWidth: 420,
   splitWidgetPanelWidth: 260,
   splitWidgetPanelCollapsed: true,
@@ -364,7 +357,6 @@ export const useSettingsStore = create<SettingsStore>()(
         const p = persisted as Partial<typeof current>;
         const persistedSettings = (p.settings ?? {}) as Partial<Settings> & {
           theme?: string;
-          layoutMode?: string;
           splitPaneSidebarWidth?: unknown;
           splitWidgetPanelWidth?: unknown;
           splitWidgetPanelCollapsed?: unknown;
@@ -381,7 +373,6 @@ export const useSettingsStore = create<SettingsStore>()(
             ...DEFAULT_SETTINGS,
             ...persistedSettings,
             theme: normalizeThemeMode(persistedSettings.theme),
-            layoutMode: normalizeLayoutMode(persistedSettings.layoutMode),
             splitPaneSidebarWidth: normalizeSplitPaneSidebarWidth(persistedSettings.splitPaneSidebarWidth),
             splitWidgetPanelWidth: normalizeSplitWidgetPanelWidth(persistedSettings.splitWidgetPanelWidth),
             splitWidgetPanelCollapsed: persistedSettings.splitWidgetPanelCollapsed === true,

--- a/src/store/workbenchStore.ts
+++ b/src/store/workbenchStore.ts
@@ -19,7 +19,7 @@ interface WorkbenchStore {
 
 export const useWorkbenchStore = create<WorkbenchStore>()((set) => ({
   sidebarSection: "sessions",
-  centerSurface: "session",
+  centerSurface: "welcome",
   focusedSessionId: null,
 
   setSidebarSection: (section) => set({ sidebarSection: section }),
@@ -42,7 +42,7 @@ export const useWorkbenchStore = create<WorkbenchStore>()((set) => ({
   }),
   resetWorkbenchMode: () => set({
     sidebarSection: "sessions",
-    centerSurface: "session",
+    centerSurface: "welcome",
     focusedSessionId: null,
   }),
 }));

--- a/src/workbench/WorkbenchCenter.tsx
+++ b/src/workbench/WorkbenchCenter.tsx
@@ -1,7 +1,146 @@
 import { SplitDetailHost } from "../components/SplitSwapLayout";
 import { ExploreEditor } from "../components/ExploreMode";
+import { showSessionSurface, showExplorer, showScm } from "../services/workbenchCommands";
+import { useSettingsStore } from "../store/settingsStore";
+import { useWorkspaceStore } from "../store/workspaceStore";
 import { useWorkbenchStore } from "../store/workbenchStore";
-import { type ClaudeSession } from "../store/sessionStore";
+import { useSessionStore, type ClaudeSession } from "../store/sessionStore";
+
+function WelcomeAction({ label, accent = false, onClick }: { label: string; accent?: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        background: "none",
+        border: "none",
+        padding: "4px 2px",
+        color: accent ? "var(--ci-accent)" : "var(--ci-text-muted)",
+        fontSize: 12,
+        fontWeight: 600,
+        cursor: "pointer",
+      }}
+      onMouseEnter={e => {
+        e.currentTarget.style.opacity = "0.8";
+      }}
+      onMouseLeave={e => {
+        e.currentTarget.style.opacity = "1";
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function WelcomeList({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div style={{ fontSize: 10, color: "var(--ci-text-dim)", fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase" }}>
+        {title}
+      </div>
+      <div style={{ marginTop: 10 }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function WelcomeEntry({
+  title,
+  detail,
+  action,
+}: {
+  title: string;
+  detail?: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 18, padding: "10px 0", borderTop: "1px solid var(--ci-toolbar-border)" }}>
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div style={{ fontSize: 13, fontWeight: 600, color: "var(--ci-text)" }}>{title}</div>
+        {detail && <div style={{ marginTop: 3, fontSize: 11, color: "var(--ci-text-dim)", lineHeight: 1.6 }}>{detail}</div>}
+      </div>
+      {action && <div style={{ flexShrink: 0 }}>{action}</div>}
+    </div>
+  );
+}
+
+function WorkbenchWelcome({ session }: { session: ClaudeSession | null }) {
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
+  const activeWorkspace = useWorkspaceStore((s) => s.workspaces.find((workspace) => workspace.id === s.activeWorkspaceId) ?? null);
+  const openSettings = useSettingsStore((s) => s.openSettings);
+  const sessions = useSessionStore((s) => s.sessions);
+  const hasWorkspace = workspaces.length > 0;
+  const recentSessions = activeWorkspace
+    ? sessions.filter((item) => item.workspaceId === activeWorkspace.id).slice(0, 5)
+    : [];
+
+  return (
+    <div style={{ width: "100%", height: "100%", overflowY: "auto" }}>
+      <div style={{ width: "100%", maxWidth: 760, margin: "0 auto", padding: "36px 30px 44px", boxSizing: "border-box" }}>
+        <div style={{ fontSize: 10, color: "var(--ci-text-dim)", fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase" }}>
+          Get Started
+        </div>
+        <div style={{ marginTop: 8, fontSize: 26, fontWeight: 700, color: "var(--ci-text)", letterSpacing: -0.5, lineHeight: 1.15 }}>
+          {hasWorkspace ? (activeWorkspace ? activeWorkspace.name : "Welcome") : "No workspace"}
+        </div>
+        <div style={{ marginTop: 8, maxWidth: 520, fontSize: 12, color: "var(--ci-text-muted)", lineHeight: 1.7 }}>
+          {hasWorkspace ? "Choose where to continue." : "Add a project folder to begin."}
+        </div>
+
+        <div style={{ marginTop: 30, display: "grid", gridTemplateColumns: "minmax(0, 1fr) minmax(0, 1fr)", gap: 36 }}>
+          {hasWorkspace ? (
+            <>
+              <WelcomeList title="Start">
+                {session ? (
+                  <>
+                    <WelcomeEntry title="Open current session" action={<WelcomeAction label="Open" accent onClick={() => showSessionSurface(session.id)} />} />
+                    <WelcomeEntry title="Open Explorer" action={<WelcomeAction label="Explorer" onClick={() => showExplorer(session.id)} />} />
+                    <WelcomeEntry title="Open Source Control" action={<WelcomeAction label="SCM" onClick={() => showScm(session.id)} />} />
+                  </>
+                ) : (
+                  <WelcomeEntry title="Create or choose a session" detail="Use the sidebar on the left." />
+                )}
+              </WelcomeList>
+              <WelcomeList title="Recent">
+                {recentSessions.length > 0 ? recentSessions.map((recent) => (
+                  <WelcomeEntry
+                    key={recent.id}
+                    title={recent.name}
+                    detail={recent.currentTask || undefined}
+                    action={<WelcomeAction label="Open" onClick={() => showSessionSurface(recent.id)} />}
+                  />
+                )) : (
+                  <WelcomeEntry title="No recent sessions" />
+                )}
+              </WelcomeList>
+            </>
+          ) : (
+            <>
+              <WelcomeList title="Start">
+                <WelcomeEntry
+                  title="Add workspace"
+                  detail="Use the Workspace section in the sidebar."
+                  action={<WelcomeAction label="Open Settings" accent onClick={() => openSettings("appearance")} />}
+                />
+                <WelcomeEntry title="Create a session" detail="Available after a workspace is added." />
+              </WelcomeList>
+              <WelcomeList title="Overview">
+                <WelcomeEntry title="Explorer and SCM" detail="Appear after a workspace is available." />
+                <WelcomeEntry title="Split workbench" detail="Sidebar, center editor/detail, and widgets." />
+              </WelcomeList>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export function WorkbenchCenter({
   session,
@@ -11,6 +150,10 @@ export function WorkbenchCenter({
   onRefreshDiff: (sessionId?: string | null, options?: { reloadExplorer?: boolean }) => void;
 }) {
   const centerSurface = useWorkbenchStore((s) => s.centerSurface);
+
+  if (centerSurface === "welcome") {
+    return <WorkbenchWelcome session={session} />;
+  }
 
   if (centerSurface === "editor" || centerSurface === "diff") {
     return <ExploreEditor session={session} onRefreshDiff={onRefreshDiff} />;


### PR DESCRIPTION
Make split workbench the only layout, add a dedicated welcome surface, and tighten related entry/collapse flows so the startup experience feels more coherent.