### PR TITLE
docs: refresh README landing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,253 +1,198 @@
-# Code Bar
+<p align="center">
+  <img src="src-tauri/icons/128x128.png" alt="Code Bar" width="104" height="104">
+</p>
 
-<div align="center">
+<h1 align="center">Code Bar</h1>
 
-A macOS / Windows desktop app built with Tauri + React, with menu bar / tray entry points. Unified management of multiple AI coding tools (Claude Code, Codex, custom CLI, built-in Harness) with Git worktree isolation, PTY terminal integration, and persistent session state.
+<p align="center">
+  <strong>Parallel AI coding, without repo chaos.</strong>
+  <br>
+  A desktop workbench for Claude Code, Codex, and custom AI CLIs.
+  <br>
+  Run multiple coding sessions across repos, isolate each one in its own git worktree, and review terminal output, files, and diffs in one place.
+  <br><br>
+  <strong>English</strong> | <a href="./README.zh.md">简体中文</a>
+</p>
 
-<p>
-  <a href="https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-windows-x64.msi">Windows x64 MSI</a> |
-  <a href="https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-macos-apple-silicon.dmg">macOS Apple Silicon</a> |
+<p align="center">
+  <a href="https://github.com/For-Tr/Code-Bar/releases/latest"><img src="https://img.shields.io/github/v/release/For-Tr/Code-Bar?style=flat-square&label=release&color=blue" alt="Latest Release"></a>
+  <a href="https://github.com/For-Tr/Code-Bar/stargazers"><img src="https://img.shields.io/github/stars/For-Tr/Code-Bar?style=flat-square&color=yellow" alt="Stars"></a>
+  <a href="https://github.com/For-Tr/Code-Bar/releases"><img src="https://img.shields.io/github/downloads/For-Tr/Code-Bar/total?style=flat-square&label=downloads" alt="Downloads"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/For-Tr/Code-Bar?style=flat-square" alt="License"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-windows-x64.msi">Windows</a> ·
+  <a href="https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-macos-apple-silicon.dmg">macOS Apple Silicon</a> ·
   <a href="https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-macos-intel.dmg">macOS Intel</a>
 </p>
 
-<p>
-  <a href="https://github.com/For-Tr/Code-Bar/releases/latest">Latest Release</a> |
-  <a href="https://github.com/For-Tr/Code-Bar/actions/workflows/release.yml">Release Action</a> |
-  <a href="https://github.com/For-Tr/Code-Bar/actions">All Actions</a>
+<p align="center">
+  <a href="https://github.com/For-Tr/Code-Bar/releases/latest">Download</a> ·
+  <a href="#quick-start">Quick Start</a> ·
+  <a href="#features">Features</a> ·
+  <a href="#build-from-source">Build from Source</a> ·
+  <a href="https://github.com/For-Tr/Code-Bar/stargazers">Star</a>
 </p>
-
-English | [简体中文](./README.zh.md) | [العربية](./README.ar.md)
-
-</div>
-
-## 👀 Screenshots
 
 <p align="center">
-  <img src="https://i.meee.com.tw/LQHF9Yg.png" alt="Home" width="31%" />
-  <img src="https://i.meee.com.tw/PIGq5LH.png" alt="Session Creation" width="31%" />
-  <img src="https://i.meee.com.tw/Bee0jnq.png" alt="CLI Settings" width="31%" />
+  <img src="https://github.com/user-attachments/assets/483c38de-69ed-4c90-9cb5-8548aa37fec2" alt="Code Bar demo" width="960" />
 </p>
-<p align="center"><em>Home · Session Creation · CLI Settings</em></p>
+
+## Why Code Bar
+
+AI coding gets messy fast: too many terminal tabs, mixed branches, and no clean place to review what changed.
+
+Code Bar gives each task its own session and worktree so you can run AI coding in parallel without losing control.
+
+- Run multiple AI coding sessions in parallel
+- Auto-isolate every session in its own git worktree
+- Review terminal output, files, SCM, and diffs in one app
+- Use Claude Code, Codex, a custom CLI, or the built-in Native Harness
+- Resume sessions across restarts and get notified when work finishes
+
+## Best for
+
+- Claude Code and Codex power users
+- Full-stack developers working across multiple repos
+- Developers who want safer parallel AI-assisted coding workflows
+- Anyone who wants a desktop workflow around terminal-native AI tools
+
 <p align="center">
-  <img src="https://i.meee.com.tw/pXlTrIe.png" alt="Strictly isolated worktree workspace and clear code diff" width="94%" />
+  <img src="https://github.com/user-attachments/assets/c030fa66-e6ea-4274-a15d-0e2fb499a58b" alt="Code Bar screenshot" width="960" />
 </p>
-<p align="center"><em>Strictly isolated worktree workspace and clear code diff</em></p>
 
-## ✨ Features
+## How it works
 
-- **🎯 Universal Runner** - Claude Code, OpenAI Codex, custom CLI, and built-in Native Harness — all in one place
-- **🤖 Multi-Provider** - Anthropic Claude, OpenAI GPT, DeepSeek, and any OpenAI-compatible API (default: Zhipu GLM-4-Flash)
-- **🌿 Git Worktree Isolation** - Each session automatically gets its own `ci/session-N` worktree branch, eliminating multi-session code conflicts
-- **🖥️ PTY Terminal** - Full xterm.js PTY terminal per session; interact with AI CLIs directly in the app
-- **🪟 Windows Compatibility** - Windows CLI path detection, `.cmd` / `.bat` shim handling, PowerShell hook bridge, and native folder picker
-- **📊 Git Diff Viewer** - Live diff display with diff2html rendering, auto-refresh at configurable intervals
-- **🔧 Native Harness** - Direct LLM API calls without any external CLI dependency
-- **🎨 Adaptive Theme** - Light / Dark / System themes with Framer Motion animations and menu bar / tray entry points
-- **📍 Position Memory** - Window position and size are remembered across restarts
-- **🔔 Notification Callback** - Native click-to-focus notifications on macOS, desktop notification fallback on Windows
-- **⚙️ Rich Settings** - Runner, model, API keys, tool permissions, and appearance — all configurable
+1. Add one or more workspaces.
+2. Start a session with Claude Code, Codex, a custom CLI, or Native Harness.
+3. Code Bar creates an isolated git worktree for that session.
+4. Watch terminal output and review files and diffs without leaving the app.
 
-## 🚀 Quick Start
+## Quick Start
 
-### Supported Platforms
+### Step 1: Download the app
 
-- **macOS** - standard app activation with a menu bar icon, native notification click callback
-- **Windows** - tray mode, PowerShell / loopback TCP bridge for hooks and notifications
+- [Windows x64 MSI](https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-windows-x64.msi)
+- [macOS Apple Silicon DMG](https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-macos-apple-silicon.dmg)
+- [macOS Intel DMG](https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-macos-intel.dmg)
+
+### Step 2: Choose your runner
+
+Use the AI coding tool you already prefer:
+
+- **Claude Code**
+- **OpenAI Codex**
+- **Custom CLI**
+- **Native Harness** for direct model access without an external CLI
+
+### Step 3: Add a workspace and start a session
+
+Open your repo, create a session, and let Code Bar keep each task isolated in its own worktree.
+
+## Features
+
+### Parallel session workflow
+
+- Create and manage multiple AI coding sessions
+- Track session status: `idle` / `running` / `waiting` / `suspended` / `done` / `error`
+- Persist session state across restarts
+- Get native notifications when tasks finish
+
+### Git worktree isolation
+
+- Automatically create a dedicated git worktree for each session
+- Keep parallel AI changes separated and avoid branch conflicts
+- Review branch-aware diffs inside the app
+- Clean up worktrees when sessions are removed
+
+### In-app review and terminal
+
+- Full xterm.js PTY terminal for each session
+- File explorer and SCM sidebar
+- Inline diff viewing with diff2html
+- Quick switching across workspaces and sessions
+
+### Runner flexibility
+
+- Claude Code, Codex, custom CLI, and Native Harness in one place
+- Runner-specific API key and base URL overrides
+- Local model/provider configuration for Native Harness
+- In-app install terminal for supported CLIs
+
+## Supported Runners
+
+| Runner | Description |
+| --- | --- |
+| **Claude Code** | Official Anthropic Claude Code CLI (`@anthropic-ai/claude-code`) |
+| **OpenAI Codex** | OpenAI Codex CLI (`@openai/codex`) |
+| **Custom CLI** | Bring your own AI CLI tool |
+| **Native Harness** | Built-in LLM integration with no external CLI required |
+
+## Platforms
+
+- **macOS**: standard app activation with a menu bar icon and native click-to-focus notifications
+- **Windows**: tray mode, PowerShell hook bridge, CLI path detection, and `.cmd` / `.bat` PTY compatibility
+
+## Build from Source
 
 ### Prerequisites
 
 - Node.js 18+
 - pnpm
-- Rust (for Tauri backend)
+- Rust
 - System dependencies:
   - **macOS**: Xcode Command Line Tools
-  - **Windows**: Microsoft C++ Build Tools and WebView2 for local development/builds (see [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/))
+  - **Windows**: Microsoft C++ Build Tools and WebView2 (see [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/))
 
-### Installation
+### Install
 
 ```bash
-# Clone the repository
 git clone https://github.com/For-Tr/code-bar.git
 cd code-bar
-
-# Install dependencies
 pnpm install
 ```
 
 ### Development
 
 ```bash
-# Run the full Tauri app in development
 pnpm tauri dev
+```
 
-# Frontend-only development server
+For frontend-only development:
+
+```bash
 pnpm dev
 ```
 
-When multiple worktrees run `pnpm tauri dev` at the same time, Code Bar automatically picks a free Vite/HMR port pair and updates Tauri `devUrl` to match.
-
-### Build
+### Production build
 
 ```bash
-# Build for production
 pnpm build
-
-# Bundle the application
 pnpm tauri build
 ```
 
-## 📖 Features
+<details>
+<summary>Development notes</summary>
 
-### Runner System
+When multiple worktrees run `pnpm tauri dev` at the same time, Code Bar automatically picks a free Vite/HMR port pair and updates Tauri `devUrl` to match.
 
-| Runner | Description |
-|--------|-------------|
-| **Claude Code** | Official Anthropic Claude Code CLI (`@anthropic-ai/claude-code`) |
-| **OpenAI Codex** | OpenAI Codex CLI (`@openai/codex`) |
-| **Custom CLI** | Bring your own AI CLI tool |
-| **Native Harness** | Built-in LLM integration — no CLI required |
+</details>
 
-Each CLI runner supports:
-- Custom binary path (auto-detects from PATH via nvm/mise/pyenv)
-- Extra CLI arguments
-- Custom API base URL override (e.g. for proxies or OpenRouter)
-- Per-runner API key override
-- In-app install terminal (one-click `npm install -g` for Claude Code / Codex)
+## Contributing
 
-### Multi-Provider Support
-
-| Provider | Models |
-|----------|--------|
-| **Anthropic** | claude-opus-4-5, claude-sonnet-4-5, claude-haiku-3-5 |
-| **OpenAI** | o3, o4-mini, gpt-4o, gpt-4.1 |
-| **DeepSeek** | deepseek-chat, deepseek-reasoner |
-| **OpenAI-Compatible** | Any model (default: glm-4-flash via Zhipu AI) |
-
-API keys are stored locally via the Tauri Rust backend (currently app-data files with lightweight obfuscation).
-
-### Session Management
-- Create and delete sessions, grouped by workspace
-- Session status tracking: idle / running / waiting / suspended / done / error
-- Persistent session state across restarts
-- Real-time PTY output streaming
-- System notification on task completion (click to focus)
-
-### Workspace Management
-- Add and manage multiple code workspaces
-- Automatic workspace directory trust (writes to `~/.claude/settings.json`)
-- Quick workspace switching with color-coded cards
-- **Git Worktree Auto-Isolation**: creates a `ci/session-N` branch worktree per session; cleans up on session delete; prunes orphan worktrees on startup
-
-### PTY Terminal
-- Full xterm.js PTY per session
-- Pre-warm launch — terminal is ready before you type
-- Injects `CODE_BAR_*` context environment variables for AI awareness
-- Resizable panel with size memory
-- OS-aware shell startup, including `.cmd` / `.bat` shim handling on Windows
-
-### Git Integration
-- Visual Git diff with diff2html rendering
-- Branch-aware diff (`base...session` branch)
-- Per-file change viewing with syntax highlighting
-- Inline diff display
-- Auto-refresh at configurable intervals (default: 5s)
-
-## 🛠️ Tech Stack
-
-### Frontend
-- **Framework**: React 19.1 + TypeScript
-- **Build Tool**: Vite 7
-- **Styling**: Tailwind CSS v4
-- **Animation**: Framer Motion
-- **State Management**: Zustand with persistence
-- **Terminal**: xterm.js with PTY support
-- **Diff Rendering**: diff2html
-
-### Backend
-- **Framework**: Tauri 2 (Rust)
-- **PTY**: portable-pty
-- **Key Storage**: Local app-data persistence handled by Tauri Rust commands
-- **Notifications**: `mac-notification-sys` on macOS, `tauri-plugin-notification` fallback on Windows
-- **Git**: libgit2-style Rust commands (branch, worktree, diff)
-- **Hook Server**: Unix Domain Socket / loopback TCP bridge for Claude Code and Codex events
-
-### Development Tools
-- **Package Manager**: pnpm
-- **Type Checking**: TypeScript 5.8
-- **Linting**: rust-analyzer
-
-## 📁 Project Structure
-
-```
-code-bar/
-├── src/                    # Frontend source code
-│   ├── components/         # React components
-│   ├── harness/            # LLM Native Harness (direct LLM API calls)
-│   ├── store/              # Zustand state management
-│   ├── assets/             # Static assets
-│   └── App.tsx             # Main application component
-├── src-tauri/              # Tauri backend (Rust)
-│   ├── src/
-│   │   ├── cli_detect.rs   # CLI path resolution (nvm/mise/pyenv aware)
-│   │   ├── git/            # Git branch, worktree, diff commands
-│   │   ├── hooks.rs        # Claude / Codex hook installers and Unix Socket / TCP bridge
-│   │   ├── notification.rs # Cross-platform notifications; macOS click callback
-│   │   ├── pty.rs          # PTY session management
-│   │   ├── session_lifecycle.rs # CLI lifecycle domain events and routing
-│   │   ├── window.rs       # Popup window control & bounds persistence
-│   │   └── lib.rs          # App entry, tray, setup
-│   └── tauri.conf.json     # Tauri configuration
-├── public/                 # Public assets
-└── package.json            # Project configuration
-```
-
-## 🎯 Keyboard Shortcuts
-
-- `Esc` - Close popup
-- `Ctrl/Cmd + ,` - Open settings
-
-## ⚙️ Configuration
-
-Application configuration is located at `src-tauri/tauri.conf.json`:
-
-- **Window**: Initial 360×220 px, transparent background, standard window stacking, hidden from the Windows taskbar
-- **Expansion**: Auto-expands to ~700×600 when PTY terminal is open
-- **Position Memory**: Last window position/size restored on next launch
-- **Behavior**: macOS uses `Regular` activation policy with a menu bar icon and standard app switching, Windows remains tray-resident
-- **Bundle ID**: `com.xiangbingzhou.code-bar`
-
-## 🪟 Platform Notes
-
-- **macOS**: uses a menu bar icon plus standard app activation, Unix Domain Socket hook bridge, and click-to-focus notification callbacks
-- **Windows**: uses tray mode, PowerShell hook bridge assets under `~/.codebar/hooks`, loopback TCP event routing, and `.cmd` / `.bat` PTY compatibility
-- **Codex on Windows**: upstream Codex hooks are currently disabled on Windows, so Code Bar configures `~/.codex/config.toml` `notify` instead of `~/.codex/hooks.json`
-
-## 🤝 Contributing
-
-Issues and Pull Requests are welcome!
+Issues and pull requests are welcome.
 
 1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add amazing feature'`)
+4. Push the branch (`git push origin feature/amazing-feature`)
+5. Open a pull request
 
-## 📄 License
+## License
 
-This project is licensed under the Apache License 2.0 - see [LICENSE](LICENSE) for details
+This project is licensed under the [Apache License 2.0](LICENSE).
 
-## 👤 Author
+## Author
 
 [@For-Tr](https://github.com/For-Tr)
-
-## 🙏 Acknowledgments
-
-- [Tauri](https://tauri.app/) - Cross-platform desktop application framework
-- [React](https://react.dev/) - UI library
-- [Anthropic Claude](https://www.anthropic.com/claude) - AI models
-- [OpenAI](https://openai.com/) - GPT models
-- [DeepSeek](https://www.deepseek.com/) - DeepSeek models
-- [Zhipu AI](https://open.bigmodel.cn/) - GLM models
-- [xterm.js](https://xtermjs.org/) - Terminal emulator
-- [diff2html](https://diff2html.xyz/) - Git diff visualization
-- [mac-notification-sys](https://github.com/h4llow3En/mac-notification-sys) - Native macOS notifications

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,250 +1,198 @@
-# Code Bar
+<p align="center">
+  <img src="src-tauri/icons/128x128.png" alt="Code Bar" width="104" height="104">
+</p>
 
-<div align="center">
+<h1 align="center">Code Bar</h1>
 
-一个基于 Tauri + React 的 macOS / Windows 桌面应用，并提供菜单栏 / 系统托盘入口，统一管理多种 AI 编程工具（Claude Code、Codex、自定义 CLI、内置 Harness）的会话，提供 Git worktree 隔离、PTY 终端集成、会话状态持久化等开发增强功能。
+<p align="center">
+  <strong>并行 AI 编程，不再把仓库搞乱。</strong>
+  <br>
+  一个面向 Claude Code、Codex 和自定义 AI CLI 的桌面工作台。
+  <br>
+  在多个仓库里并行运行编码会话，为每个会话自动创建独立 git worktree，并在一个界面里查看终端输出、文件和 diff。
+  <br><br>
+  <a href="./README.md">English</a> | <strong>简体中文</strong>
+</p>
 
-<p>
-  <a href="https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-windows-x64.msi">Windows x64 MSI</a> |
-  <a href="https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-macos-apple-silicon.dmg">macOS Apple Silicon</a> |
+<p align="center">
+  <a href="https://github.com/For-Tr/Code-Bar/releases/latest"><img src="https://img.shields.io/github/v/release/For-Tr/Code-Bar?style=flat-square&label=release&color=blue" alt="最新版本"></a>
+  <a href="https://github.com/For-Tr/Code-Bar/stargazers"><img src="https://img.shields.io/github/stars/For-Tr/Code-Bar?style=flat-square&color=yellow" alt="Stars"></a>
+  <a href="https://github.com/For-Tr/Code-Bar/releases"><img src="https://img.shields.io/github/downloads/For-Tr/Code-Bar/total?style=flat-square&label=downloads" alt="下载量"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/For-Tr/Code-Bar?style=flat-square" alt="许可证"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-windows-x64.msi">Windows</a> ·
+  <a href="https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-macos-apple-silicon.dmg">macOS Apple Silicon</a> ·
   <a href="https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-macos-intel.dmg">macOS Intel</a>
 </p>
 
-<p>
-  <a href="https://github.com/For-Tr/Code-Bar/releases/latest">最新 Release</a> |
-  <a href="https://github.com/For-Tr/Code-Bar/actions/workflows/release.yml">Release Action</a> |
-  <a href="https://github.com/For-Tr/Code-Bar/actions">全部 Actions</a>
+<p align="center">
+  <a href="https://github.com/For-Tr/Code-Bar/releases/latest">下载</a> ·
+  <a href="#快速开始">快速开始</a> ·
+  <a href="#功能特性">功能特性</a> ·
+  <a href="#从源码构建">从源码构建</a> ·
+  <a href="https://github.com/For-Tr/Code-Bar/stargazers">Star</a>
 </p>
-
-[English](./README.md) | 简体中文 | [العربية](./README.ar.md)
-
-</div>
-
-## 👀 界面预览
 
 <p align="center">
-  <img src="https://i.meee.com.tw/LQHF9Yg.png" alt="主页" width="31%" />
-  <img src="https://i.meee.com.tw/PIGq5LH.png" alt="会话创建页" width="31%" />
-  <img src="https://i.meee.com.tw/Bee0jnq.png" alt="CLI 页面" width="31%" />
+  <img src="https://github.com/user-attachments/assets/483c38de-69ed-4c90-9cb5-8548aa37fec2" alt="Code Bar 演示" width="960" />
 </p>
-<p align="center"><em>主页 · 会话创建页 · CLI 页面</em></p>
+
+## 为什么是 Code Bar
+
+AI 编程一旦并行起来，很快就会变乱：终端标签太多、分支互相污染、改动也没有一个顺手的地方统一查看。
+
+Code Bar 把每个任务放进独立 session 和 worktree，让你能并行运行 AI 编程流程，同时保持可控。
+
+- 并行运行多个 AI 编码会话
+- 为每个会话自动创建独立 git worktree
+- 在一个应用里查看终端输出、文件、SCM 和 diff
+- 支持 Claude Code、Codex、自定义 CLI，以及内置 Native Harness
+- 会话状态跨重启保留，任务完成后可收到通知
+
+## 适合谁
+
+- Claude Code 和 Codex 的重度用户
+- 需要跨多个仓库工作的全栈开发者
+- 想更安全地并行使用 AI 辅助编程的开发者
+- 希望围绕终端型 AI 工具建立桌面工作流的用户
+
 <p align="center">
-  <img src="https://i.meee.com.tw/pXlTrIe.png" alt="严格区分的worktree工作区与清晰的代码diff" width="94%" />
+  <img src="https://github.com/user-attachments/assets/c030fa66-e6ea-4274-a15d-0e2fb499a58b" alt="Code Bar 截图" width="960" />
 </p>
-<p align="center"><em>严格区分的worktree工作区与清晰的代码diff</em></p>
 
-## ✨ 特性
+## 工作方式
 
-- **🎯 通用 Runner** - Claude Code、OpenAI Codex、自定义 CLI、内置 Native Harness，统一管理
-- **🤖 多 Provider** - Anthropic Claude、OpenAI GPT、DeepSeek、任意 OpenAI 兼容接口（默认：智谱 GLM-4-Flash）
-- **🌿 Git Worktree 隔离** - 每个 session 自动在独立 `ci/session-N` worktree 分支中工作，彻底消除多 session 代码冲突
-- **🖥️ PTY 终端** - 每个 session 独立 xterm.js PTY 终端，直接在应用中与 AI CLI 交互
-- **🪟 Windows 适配** - 支持 Windows CLI 路径检测、`.cmd` / `.bat` shim 处理、PowerShell hook bridge 以及原生目录选择
-- **📊 Git Diff 查看** - 实时 diff 展示（diff2html 渲染），可配置自动刷新间隔
-- **🔧 内置 Harness** - 无需外部 CLI，直接调用 LLM API 执行任务
-- **🎨 自适应主题** - 浅色 / 深色 / 跟随系统，Framer Motion 流畅动画，并提供菜单栏 / 托盘入口
-- **📍 位置记忆** - 浮窗位置与大小跨重启自动恢复
-- **🔔 通知回调** - macOS 原生通知支持点击聚焦，Windows 使用桌面通知降级方案
-- **⚙️ 丰富设置** - Runner、模型、API Key、工具权限、外观，全部可自定义
+1. 添加一个或多个工作区。
+2. 用 Claude Code、Codex、自定义 CLI 或 Native Harness 启动一个 session。
+3. Code Bar 为这个 session 自动创建独立的 git worktree。
+4. 不离开应用，直接查看终端输出、文件和 diff。
 
-## 🚀 快速开始
+## 快速开始
 
-### 支持平台
+### 第一步：下载安装
 
-- **macOS** - 标准应用激活行为 + 菜单栏图标，原生通知点击回调
-- **Windows** - 托盘模式，基于 PowerShell / 本地回环 TCP 的 hook 与通知桥接
+- [Windows x64 MSI](https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-windows-x64.msi)
+- [macOS Apple Silicon DMG](https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-macos-apple-silicon.dmg)
+- [macOS Intel DMG](https://github.com/For-Tr/Code-Bar/releases/latest/download/code-bar-macos-intel.dmg)
+
+### 第二步：选择你的 runner
+
+继续使用你已经熟悉的 AI 编程工具：
+
+- **Claude Code**
+- **OpenAI Codex**
+- **自定义 CLI**
+- **Native Harness**：无需外部 CLI，直接访问模型
+
+### 第三步：添加工作区并启动 session
+
+打开你的仓库，创建一个 session，让 Code Bar 为每个任务保持独立 worktree。
+
+## 功能特性
+
+### 并行会话工作流
+
+- 创建和管理多个 AI 编码会话
+- 跟踪会话状态：`idle` / `running` / `waiting` / `suspended` / `done` / `error`
+- 会话状态跨重启保留
+- 任务完成后接收原生通知
+
+### Git worktree 隔离
+
+- 为每个 session 自动创建专属 git worktree
+- 让并行 AI 改动彼此隔离，避免分支冲突
+- 在应用内查看基于分支的 diff
+- 删除 session 时自动清理 worktree
+
+### 应用内审阅与终端
+
+- 每个 session 都有完整的 xterm.js PTY 终端
+- 内置文件树和 SCM 侧边栏
+- 用 diff2html 进行内联 diff 展示
+- 快速切换工作区和 session
+
+### 灵活的 runner 支持
+
+- Claude Code、Codex、自定义 CLI 和 Native Harness 统一管理
+- 支持 runner 级 API Key 和 Base URL 覆盖
+- Native Harness 支持本地模型 / provider 配置
+- 对支持的 CLI 提供应用内安装终端
+
+## 支持的 Runner
+
+| Runner | 说明 |
+| --- | --- |
+| **Claude Code** | Anthropic 官方 Claude Code CLI（`@anthropic-ai/claude-code`） |
+| **OpenAI Codex** | OpenAI Codex CLI（`@openai/codex`） |
+| **自定义 CLI** | 接入你自己的 AI CLI 工具 |
+| **Native Harness** | 内置 LLM 集成，无需外部 CLI |
+
+## 支持平台
+
+- **macOS**：标准应用激活方式、菜单栏图标，以及原生点击聚焦通知
+- **Windows**：托盘模式、PowerShell hook bridge、CLI 路径检测，以及 `.cmd` / `.bat` PTY 兼容处理
+
+## 从源码构建
 
 ### 环境要求
 
 - Node.js 18+
 - pnpm
-- Rust（用于 Tauri 后端）
+- Rust
 - 系统依赖：
-  - **macOS**: Xcode Command Line Tools
-  - **Windows**: 本地开发 / 构建需要 Microsoft C++ Build Tools 和 WebView2（缺失时请参考 [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/)）
+  - **macOS**：Xcode Command Line Tools
+  - **Windows**：Microsoft C++ Build Tools 和 WebView2（见 [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/)）
 
 ### 安装
 
 ```bash
-# 克隆仓库
 git clone https://github.com/For-Tr/code-bar.git
 cd code-bar
-
-# 安装依赖
 pnpm install
 ```
 
 ### 开发
 
 ```bash
-# 启动完整的 Tauri 开发环境
 pnpm tauri dev
+```
 
-# 仅启动前端开发服务器
+如果只跑前端开发服务器：
+
+```bash
 pnpm dev
 ```
 
-当多个 worktree 同时执行 `pnpm tauri dev` 时，Code Bar 会自动选择空闲的 Vite/HMR 端口，并同步更新 Tauri 的 `devUrl`。
-
-### 构建
+### 生产构建
 
 ```bash
-# 构建生产版本
 pnpm build
-
-# 打包应用
 pnpm tauri build
 ```
 
-## 📖 功能说明
+<details>
+<summary>开发说明</summary>
 
-### Runner 系统
+当多个 worktree 同时运行 `pnpm tauri dev` 时，Code Bar 会自动选择空闲的 Vite/HMR 端口，并同步更新 Tauri 的 `devUrl`。
 
-| Runner | 说明 |
-|--------|------|
-| **Claude Code** | Anthropic 官方 CLI（`@anthropic-ai/claude-code`） |
-| **OpenAI Codex** | OpenAI Codex CLI（`@openai/codex`） |
-| **自定义 CLI** | 任意 AI CLI 工具 |
-| **Native Harness** | 内置 LLM 集成，无需外部 CLI |
+</details>
 
-每种 CLI Runner 支持：
-- 自定义可执行文件路径（自动从 PATH 检测，兼容 nvm/mise/pyenv）
-- 附加 CLI 参数
-- 自定义 API Base URL（适用于代理/OpenRouter 等场景）
-- 独立 API Key 覆盖
-- 应用内安装终端（一键 `npm install -g` 安装 Claude Code / Codex）
+## 贡献
 
-### 多 Provider 支持
-
-| Provider | 可用模型 |
-|----------|---------|
-| **Anthropic** | claude-opus-4-5、claude-sonnet-4-5、claude-haiku-3-5 |
-| **OpenAI** | o3、o4-mini、gpt-4o、gpt-4.1 |
-| **DeepSeek** | deepseek-chat、deepseek-reasoner |
-| **OpenAI 兼容** | 任意模型（默认：智谱 glm-4-flash） |
-
-API Key 通过 Tauri Rust 后端持久化到本地应用数据目录（当前为轻量混淆存储）。
-
-### 会话管理
-- 创建、删除会话，按工作区分组
-- 状态跟踪：空闲 / 运行中 / 等待确认 / 已挂起 / 完成 / 出错
-- 会话状态跨重启持久化
-- PTY 实时输出流
-- 任务完成时发送系统通知（点击通知聚焦 session）
-
-### 工作区管理
-- 添加和管理多个代码工作区
-- 自动信任工作区目录（写入 `~/.claude/settings.json`）
-- 彩色卡片快速切换工作区
-- **Git Worktree 自动隔离**：新建 session 时自动创建 `ci/session-N` 分支的 worktree，PTY 在隔离目录中运行；session 删除时自动清理；启动时自动清理孤儿 worktree
-
-### PTY 终端
-- 每个 session 独立 xterm.js PTY
-- 预热启动——终端在用户输入前已就绪
-- 自动注入 `CODE_BAR_*` 上下文环境变量，供 AI 感知 session 信息
-- 可调整大小的面板，尺寸持久化
-- 按平台选择启动方式，Windows 下额外处理 `.cmd` / `.bat` shim 兼容性
-
-### Git 集成
-- diff2html 可视化 Git diff
-- 分支感知 diff（对比 `base...session` 分支）
-- 支持分文件查看变更，语法高亮
-- 行内差异显示
-- 可配置自动刷新间隔（默认 5 秒）
-
-## 🛠️ 技术栈
-
-### 前端
-- **框架**: React 19.1 + TypeScript
-- **构建工具**: Vite 7
-- **样式**: Tailwind CSS v4
-- **动画**: Framer Motion
-- **状态管理**: Zustand（含持久化）
-- **终端**: xterm.js（PTY 支持）
-- **Diff 渲染**: diff2html
-
-### 后端
-- **框架**: Tauri 2 (Rust)
-- **PTY**: portable-pty
-- **密钥存储**: 由 Tauri Rust 命令写入本地应用数据目录
-- **通知**: macOS 使用 `mac-notification-sys`，Windows 使用 `tauri-plugin-notification` 降级
-- **Git**: Rust 命令（分支、worktree、diff）
-- **Hook 服务**: Unix Domain Socket / 本地回环 TCP 接收 Claude Code / Codex 事件
-
-### 开发工具
-- **包管理器**: pnpm
-- **类型检查**: TypeScript 5.8
-- **Rust 分析**: rust-analyzer
-
-## 📁 项目结构
-
-```
-code-bar/
-├── src/                    # 前端源代码
-│   ├── components/         # React 组件
-│   ├── harness/            # LLM Native Harness（直接调用 LLM API）
-│   ├── store/              # Zustand 状态管理
-│   ├── assets/             # 静态资源
-│   └── App.tsx             # 主应用组件
-├── src-tauri/              # Tauri 后端 (Rust)
-│   ├── src/
-│   │   ├── cli_detect.rs   # CLI 路径解析（兼容 nvm/mise/pyenv）
-│   │   ├── git/            # Git 分支、worktree、diff 命令
-│   │   ├── hooks.rs        # Claude / Codex hooks 安装与 Unix Socket / TCP bridge
-│   │   ├── notification.rs # 跨平台通知；macOS 支持点击回调
-│   │   ├── pty.rs          # PTY 会话管理
-│   │   ├── session_lifecycle.rs # CLI 生命周期领域事件与路由
-│   │   ├── window.rs       # 浮窗控制与位置持久化
-│   │   └── lib.rs          # 应用入口、托盘、初始化
-│   └── tauri.conf.json     # Tauri 配置
-├── public/                 # 公共资源
-└── package.json            # 项目配置
-```
-
-## 🎯 快捷键
-
-- `Esc` - 关闭弹窗
-- `Ctrl/Cmd + ,` - 打开设置
-
-## ⚙️ 配置
-
-应用配置文件位于 `src-tauri/tauri.conf.json`：
-
-- **窗口**: 初始 360×220 像素，透明背景，按常规窗口层级显示，Windows 下不显示在任务栏
-- **展开**: 打开 PTY 终端时自动扩展至约 700×600
-- **位置记忆**: 下次启动时自动恢复上次的窗口位置和尺寸
-- **行为**: macOS 使用 `Regular` 激活策略，保留菜单栏图标并采用标准应用切换行为，Windows 仍常驻系统托盘
-- **Bundle ID**: `com.xiangbingzhou.code-bar`
-
-## 🪟 平台说明
-
-- **macOS**: 提供菜单栏图标和标准应用激活行为、Unix Domain Socket hook bridge，以及支持点击回调的通知
-- **Windows**: 使用托盘模式、位于 `~/.codebar/hooks` 的 PowerShell hook bridge、本地回环 TCP 事件转发，以及 `.cmd` / `.bat` PTY 兼容处理
-- **Windows 上的 Codex**: 由于 Codex 官方当前声明 Windows hooks 已禁用，Code Bar 会改为配置 `~/.codex/config.toml` 的 `notify`，而不是 `~/.codex/hooks.json`
-
-## 🤝 贡献
-
-欢迎提交 Issue 和 Pull Request！
+欢迎提交 Issue 和 Pull Request。
 
 1. Fork 本仓库
-2. 创建特性分支 (`git checkout -b feature/AmazingFeature`)
-3. 提交更改 (`git commit -m 'Add some AmazingFeature'`)
-4. 推送到分支 (`git push origin feature/AmazingFeature`)
-5. 开启 Pull Request
+2. 创建你的功能分支（`git checkout -b feature/amazing-feature`）
+3. 提交改动（`git commit -m 'Add amazing feature'`）
+4. 推送分支（`git push origin feature/amazing-feature`）
+5. 发起 Pull Request
 
-## 📄 许可证
+## 许可证
 
-本项目采用 Apache License 2.0 - 详见 [LICENSE](LICENSE) 文件
+本项目使用 [Apache License 2.0](LICENSE)。
 
-## 👤 作者
+## 作者
 
 [@For-Tr](https://github.com/For-Tr)
-
-## 🙏 致谢
-
-- [Tauri](https://tauri.app/) - 跨平台桌面应用框架
-- [React](https://react.dev/) - 用户界面库
-- [Claude Code](https://claude.ai/code) - AI 编程助手
-- [xterm.js](https://xtermjs.org/) - 终端模拟器
-- [diff2html](https://diff2html.xyz/) - Git diff 可视化
-- [mac-notification-sys](https://github.com/h4llow3En/mac-notification-sys) - macOS 原生通知


### PR DESCRIPTION
Reframe Code Bar around parallel AI coding and worktree isolation so new visitors understand the core workflow faster. Sync the Chinese README with the same structure and assets.